### PR TITLE
Latex filter fix: The image file is now regenerated if DPI is changed.

### DIFF
--- a/filters/latex/latex2png.py
+++ b/filters/latex/latex2png.py
@@ -128,7 +128,7 @@ def latex2png(infile, outfile, dpi, modified):
     if infile == '-':
         tex = sys.stdin.read()
         if modified:
-            checksum = md5.new(tex).digest()
+            checksum = md5.new(tex + str(dpi)).digest()
             md5_file = os.path.splitext(outfile)[0] + '.md5'
             if os.path.isfile(md5_file) and os.path.isfile(outfile) and \
                     checksum == read_file(md5_file,'rb'):


### PR DESCRIPTION
My first pull request on Git Hub so I'll start out with a small one :-)

This is a small bugfix in the Latex filter. The PNG image was not regenerated if only the DPI parameter was changed. Now the DPI parameter is included in the MD5 checksum which decides if the image should be regenerated or not.

Regards,
Tobias
