### PR TITLE
Adding examples for the asciidoc man page

### DIFF
--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -353,6 +353,11 @@ SourceForge: http://sourceforge.net/projects/asciidoc/
 Main web site: http://asciidoc.org/
 
 
+SEE ALSO
+--------
+asciidoc(1)
+
+
 COPYING
 -------
 Copyright \(C) 2002-2011 Stuart Rackham. Free use of this software is

--- a/doc/asciidoc.1.txt
+++ b/doc/asciidoc.1.txt
@@ -162,6 +162,25 @@ The plugin commands perform as follows:
   names starting with a period are skipped.
 
 
+EXAMPLES
+--------
+`asciidoc asciidoc_file_name.txt`::
+  Simply generate an html file from the asciidoc_file_name.txt that is in
+  current directory using asciidoc.
+
+`asciidoc -b html5 asciidoc_file_name.txt`::
+  Use the `-b` switch to use one of the proposed backend or another one you
+  installed on your computer.
+
+`asciidoc -a data-uri -a icons -a toc -a max-width=55em article.txt`::
+  Use the `-a` switch to set attributes from command-line. AsciiDoc generated
+  its stand-alone HTML user guide containing embedded CSS, JavaScript and
+  images from the AsciiDoc article template with this command.
+
+`asciidoc -b html5 -d manpage asciidoc.1.txt`::
+  Generating the asciidoc manpage using the html5 backend.
+
+
 EXIT STATUS
 -----------
 *0*::

--- a/doc/asciidoc.1.txt
+++ b/doc/asciidoc.1.txt
@@ -209,6 +209,11 @@ SourceForge: <http://sourceforge.net/projects/asciidoc/>
 Main web site: <http://asciidoc.org/>
 
 
+SEE ALSO
+--------
+a2x(1)
+
+
 COPYING
 -------
 Copyright \(C) 2002-2011 Stuart Rackham. Free use of this software is


### PR DESCRIPTION
Dear Lex and Stuart,

Currently there are examples in a2x man page but not in the asciidoc man page.
As it is a best practice to have examples in man pages and it has been asked long time ago in:
http://bugs.debian.org/499498 , I propose you the following addition to the asciidoc man page.

Best regards,
Joseph
