### PR TITLE
Update bottom text

### DIFF
--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -5965,6 +5965,22 @@ A short summary of changes in this document revision. Must be defined
 prior to the first document section. The document also needs to be
 dated to output this attribute.
 
+|footer-style |html4, html5, xhtml11 |
+Changes the "Last updated" field in the footer of the document or removes this
+field and the revision number (in the footer only). +
+Can take 3 values:
+
+- none : Don't display the "Last updated" and "Revision number" fields in the
+  footer of the document
+- revdate : The "Last updated" field's date in the footer will be the revision
+  date specified in the document (`revdate` attribute)
+- default (or any other value) : The "Last updated" field's date in the footer
+  will be the date of the input file modification
+
+This attribute can be set, for example, using `:footer-style: revdate` in the
+header of the file or using the `--attribute footer-style=revdate` command-line
+option.
+
 |scriptsdir |html5, xhtml11 |
 The name of the directory containing linked JavaScripts.
 See <<X35,HTML stylesheets and JavaScript locations>>.

--- a/html4.conf
+++ b/html4.conf
@@ -444,11 +444,14 @@ cellspacing="0" cellpadding="4">
 |
 
 [footer]
+# Removing footer date and version if footer-style set to none
+ifeval::["{footer-style=default}"!="none"]
 <p></p>
 <p></p>
 <hr><p><small>
 template::[footer-text]
 </small></p>
+endif::[]
 </body>
 </html>
 
@@ -466,6 +469,16 @@ template::[footer-text]
 {docinfo,docinfo2#}{include:{docdir}/{docname}-docinfo.html}
 template::[docinfo]
 </head>
+
+[footer-date]
+# Default footer date is document modification time
+ifeval::["{footer-style=default}"!="revdate"]
+ {docdate} {doctime}
+endif::[]
+# If set to "revdate", it'll be set to the revision date
+ifeval::["{footer-style=default}"=="revdate"]
+ {revdate}
+endif::[]
 
 #--------------------------------
 # article and book document types

--- a/html5.conf
+++ b/html5.conf
@@ -679,9 +679,12 @@ endif::doctype-manpage[]
 </div>
 {disable-javascript%<div id="footnotes"><hr></div>}
 <div id="footer">
+# Removing footer date and version if footer-style set to none
+ifeval::["{footer-style=default}"!="none"]
 <div id="footer-text">
 template::[footer-text]
 </div>
+endif::[]
 ifdef::badges[]
 <div id="footer-badges">
 ifndef::icons[]
@@ -704,6 +707,16 @@ endif::badges[]
 </div>
 </body>
 </html>
+
+[footer-date]
+# Default footer date is document modification time
+ifeval::["{footer-style=default}"!="revdate"]
+ {docdate} {doctime}
+endif::[]
+# If set to "revdate", it'll be set to the revision date
+ifeval::["{footer-style=default}"=="revdate"]
+ {revdate}
+endif::[]
 
 ifdef::doctype-manpage[]
 [synopsis]

--- a/lang-cs.conf
+++ b/lang-cs.conf
@@ -23,7 +23,8 @@ manname-title=NAME
 
 [footer-text]
 Verze {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Poslední úprava {docdate} {doctime}
+Poslední úprava
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-de.conf
+++ b/lang-de.conf
@@ -29,7 +29,8 @@ manname-title=NAME
 
 [footer-text]
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Letzte Änderung {docdate} {doctime}
+Letzte Änderung
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-el.conf
+++ b/lang-el.conf
@@ -23,7 +23,8 @@ manname-title=ΌΝΟΜΑ
 
 [footer-text]
 Έκδοση {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Τελευταία αναθεώρηση {docdate} {doctime}
+Τελευταία αναθεώρηση
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-en.conf
+++ b/lang-en.conf
@@ -22,7 +22,8 @@ manname-title=NAME
 
 [footer-text]
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Last updated {docdate} {doctime}
+Last updated
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-es.conf
+++ b/lang-es.conf
@@ -25,7 +25,8 @@ manname-title=NOMBRE DE REFERENCIA
 [footer-text]
 #TODO: Translation of 'Version' and 'Last updated'.
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Last updated {docdate} {doctime}
+Last updated
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-fr.conf
+++ b/lang-fr.conf
@@ -27,7 +27,8 @@ manname-title=NOM
 
 [footer-text]
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Dernière mise à jour {docdate} {doctime}
+Dernière mise à jour
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-hu.conf
+++ b/lang-hu.conf
@@ -25,7 +25,8 @@ manname-title=NÉV
 
 [footer-text]
 Verzió {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Utolsó frissítés: {docdate} {doctime}
+Utolsó frissítés:
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-it.conf
+++ b/lang-it.conf
@@ -24,7 +24,8 @@ manname-title=NOME
 
 [footer-text]
 Versione {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Ultimo aggiornamento {docdate} {doctime}
+Ultimo aggiornamento
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-ja.conf
+++ b/lang-ja.conf
@@ -29,7 +29,8 @@ manname-title=名前
 
 [footer-text]
 バージョン {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-{docdate} {doctime} 更新
+template::[footer-date]
+ 更新
 
 endif::basebackend-html[]
 

--- a/lang-nl.conf
+++ b/lang-nl.conf
@@ -29,7 +29,8 @@ manname-title=NAME
 
 [footer-text]
 Versie {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Laatst bijgewerkt {docdate} {doctime}
+Laatst bijgewerkt
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-pt-BR.conf
+++ b/lang-pt-BR.conf
@@ -25,7 +25,8 @@ manname-title=NOME
 
 [footer-text]
 Versão {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Última Atualização {docdate} {doctime}
+Última Atualização
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-ro.conf
+++ b/lang-ro.conf
@@ -27,7 +27,8 @@ manname-title=NUME
 
 [footer-text]
 Versiunea {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Ultima actualizare {docdate} {doctime}
+Ultima actualizare
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-ru.conf
+++ b/lang-ru.conf
@@ -27,7 +27,8 @@ manname-title=ИМЯ
 
 [footer-text]
 Редакция {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Последнее обновление {docdate} {doctime}
+Последнее обновление
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-sv.conf
+++ b/lang-sv.conf
@@ -22,7 +22,8 @@ manname-title=NAMN
 
 [footer-text]
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Senast uppdaterad {docdate} {doctime}
+Senast uppdaterad
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/lang-uk.conf
+++ b/lang-uk.conf
@@ -28,7 +28,8 @@ manname-title=НАЗВА
 [footer-text]
 #TODO: Translation of 'Version' and 'Last updated'.
 Version {revnumber}{basebackend-xhtml11?<br />}{basebackend-xhtml11=<br>}
-Last updated {docdate} {doctime}
+Last updated
+template::[footer-date]
 
 endif::basebackend-html[]
 

--- a/tests/testasciidoc.conf
+++ b/tests/testasciidoc.conf
@@ -831,3 +831,33 @@ Swedish language file (manpage)
 data/lang-sv-man-test.txt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Last Updated field not displayed in HTML backends
+
+% backends
+['xhtml11','html4','html5']
+
+% name
+lang-en-no-last-updated-test
+
+% source
+data/lang-en-test.txt
+
+% attributes
+{'footer-style':'none'}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Last Updated field displays revision date
+
+% backends
+['xhtml11','html4','html5']
+
+% name
+lang-en-last-updated-is-revdate-test
+
+% source
+data/lang-en-test.txt
+
+% attributes
+{'footer-style':'revdate'}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -676,9 +676,12 @@ endif::doctype-manpage[]
 </div>
 {disable-javascript%<div id="footnotes"><hr /></div>}
 <div id="footer">
+# Removing footer date and version if footer-style set to none
+ifeval::["{footer-style=default}"!="none"]
 <div id="footer-text">
 template::[footer-text]
 </div>
+endif::[]
 ifdef::badges[]
 <div id="footer-badges">
 ifndef::icons[]
@@ -702,6 +705,16 @@ endif::badges[]
 </div>
 </body>
 </html>
+
+[footer-date]
+# Default footer date is document modification time
+ifeval::["{footer-style=default}"!="revdate"]
+ {docdate} {doctime}
+endif::[]
+# If set to "revdate", it'll be set to the revision date
+ifeval::["{footer-style=default}"=="revdate"]
+ {revdate}
+endif::[]
 
 ifdef::doctype-manpage[]
 [synopsis]


### PR DESCRIPTION
Hello,

NOTE: This is the same as the pull request https://github.com/asciidoc/asciidoc/pull/7, but I cleaned up the commit and used a separate branch.

First things first, thanks for your great work on this tool.

As explained in both links I propose to change the behavior of the footer-text:
https://code.google.com/p/asciidoc/issues/detail?id=29
https://groups.google.com/forum/#!topic/asciidoc/EsOmfFrlGqQ
## Context:

I (and other people, for example: http://bugs.debian.org/656736) had the issue of the modification of the "Last updated" field at the bottom of the generated page that gives the modification date of the page (not the revision date) when you use asciidoc to generate HTML pages.

For example, I'm using a central git repo for the text pages and generate the html pages using a batch. When you update repo that is used for the batch it can be at another date than the date of the revision, so the "Last updated" field at the end of the page can be confusing.
## My proposition:

What I did in the patch is I used a new standard attribute named "footer-style" (you can change it if you want!) that could take 3 values:
- default :or not defined, same as currently)
- none : not displaying the footer-text section
- revdate : displays the revision date instead of the source file modification date
  Any other value will display only the version number from the footer-text section(if defined).

On Lex's advice I put all the logic in the asciidoc.conf and the backend files in order to only have a template call in the language files.
This time I updated all language files and documentation!

Please tell me if you have any remarks about this pull request.

Thanks in advance,
Joseph
