### PR TITLE
Adding a manpage for testasciidoc.py

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -152,6 +152,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(progdir)/a2x
 	rm -f $(DESTDIR)/$(progdir)/a2x.py
 	rm -f $(DESTDIR)/$(manpdir)/asciidoc.1
+	rm -f $(DESTDIR)/$(manpdir)/testasciidoc.1
 	rm -f $(DESTDIR)/$(manpdir)/a2x.1
 	rm -rf $(DESTDIR)/$(confdir)
 	rm -rf $(DESTDIR)/$(docdir)

--- a/doc/testasciidoc.1.txt
+++ b/doc/testasciidoc.1.txt
@@ -1,0 +1,114 @@
+TESTASCIIDOC(1)
+===============
+:doctype: manpage
+
+
+NAME
+----
+testasciidoc - Run AsciiDoc conformance tests specified in configuration file.
+
+
+SYNOPSIS
+--------
+*testasciidoc* ['OPTIONS'] 'COMMAND'
+
+
+DESCRIPTION
+-----------
+The testasciidoc command runs AsciiDoc conformance tests specified in
+configuration file.
+
+
+COMMANDS
+--------
+The testasciidoc toolset has three different commands:
+
+  testasciidoc list
+  testasciidoc run [NUMBER] [BACKEND] [OPTIONS]
+  testasciidoc update [NUMBER] [BACKEND] [OPTIONS]
+
+The commands perform as follows:
+
+*list*::
+  List available tests cases.
+
+*run*::
+  Execute tests (regenerate temporary test cases and compare them to the
+  reference files).
+
+*update*::
+  Regenerate and update test data reference files.
+  Needs to be launched at least once to have the reference files to compare to
+  during the tests.
+
+Where:
+
+*NUMBER*::
+  Is the index number of the test case from the `testasciidoc list` command.
+
+*BACKEND*::
+  Is the asciidoc backend to use.
+
+*OPTIONS*::
+  Are the options listed below.
+
+
+OPTIONS
+-------
+*-f, --conf-file*='CONF_FILE'::
+    Use configuration file CONF_FILE for more information about the
+    configuration file format refer to the tests documentation.
+
+*--force*::
+    Update all test data overwriting existing data
+
+
+EXAMPLES
+--------
+`testasciidoc list`::
+  Lists all the test actions available for running or updating.
+
+`testasciidoc run`::
+  Runs all the testing actions available.
+
+`testasciidoc run 1 html5 --conf-file=/etc/asciidoc/testasciidoc.conf`::
+  Run the test case 1 for the html5 asciidoc backend using the configuration file
+  /etc/asciidoc/testasciidoc.conf.
+
+`testasciidoc update 1 html5`::
+  Generate or update the reference files used for the tests cases 1st action of
+  the html5 asciidoc backend.
+
+
+EXIT STATUS
+-----------
+*0*::
+    Success
+
+*1*::
+    Failure (syntax or usage error; configuration error; document
+    processing failure; unexpected error).
+
+
+BUGS
+----
+See the AsciiDoc distribution BUGS file.
+
+
+AUTHOR
+------
+AsciiDoc was originally written by Stuart Rackham. Many people have
+contributed to it.
+
+
+RESOURCES
+---------
+GitHub: <https://github.com/asciidoc/asciidoc>
+
+Main web site: <http://asciidoc.org/>
+
+
+SEE ALSO
+--------
+asciidoc(1), a2x(1)
+


### PR DESCRIPTION
Hi,

In Debian, every distributed binaries are supposed to have a man page.
So as I've written this one for testasciidoc in Debian. Are you interested in integrating it to official asciidoc?
If so, can you validate this manpage looks good to you please?

Thanks in advance,
Joseph
