### PR TITLE
Fixing bug for embedded image corruption

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -52,7 +52,7 @@ filters/code/code-filter.conf
 filters/code/code-filter.py
 filters/code/code-filter-readme.txt
 filters/code/code-filter-test.txt
-filters/latex/latex2png.py
+filters/latex/latex2img.py
 filters/latex/latex-filter.conf
 filters/music/music-filter.conf
 filters/music/music2png.py

--- a/Makefile.in
+++ b/Makefile.in
@@ -53,7 +53,7 @@ musicfilterconfdir = $(filtersdir)/music
 sourcefilterconf = filters/source/source-highlight-filter.conf
 sourcefilterconfdir = $(filtersdir)/source
 
-latexfilter = filters/latex/latex2png.py
+latexfilter = filters/latex/latex2img.py
 latexfilterdir = $(filtersdir)/latex
 latexfilterconf = filters/latex/latex-filter.conf
 latexfilterconfdir = $(filtersdir)/latex

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -80,7 +80,8 @@ latexmath-style=template="latexmathblock",subs=()
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\"data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print 'src=\"data:'+mimetypes.guess_type(r'{target}')[0]+';base64,';"}
+{data-uri#}{sys3:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </span>
 


### PR DESCRIPTION
Hi,
I fixed a bug where and image was corrupted when using the image-inlinemacro for xhmtl11.
The issue was present on both cygwin and Ubuntu using python 2.7

I also fixed the makefile since the latex2png was renamed to latex2img.
With these changes I was able to install and build my documents.

Thanks,
Peter Bruin
