### PR TITLE
Apêndice only has has one "p": PT-BR translation

### DIFF
--- a/lang-pt-BR.conf
+++ b/lang-pt-BR.conf
@@ -48,7 +48,7 @@ endif::doctype-book[]
 ^Índice$=index
 ^(Bibliografia|Referências)$=bibliography
 ^Glossário$=glossary
-^Appêndice [A-Z][:.](?P<title>.*)$=appendix
+^Apêndice [A-Z][:.](?P<title>.*)$=appendix
 
 endif::basebackend-docbook[]
 


### PR DESCRIPTION
As you can see at: http://www.priberam.pt/dlpo/ap%C3%AAndice
