### PR TITLE
Bug with bibliography example in documentation

### DIFF
--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -2168,8 +2168,8 @@ generating DocBook bibliography entries. Example:
 - [[[taoup]]] Eric Steven Raymond. 'The Art of UNIX
   Programming'. Addison-Wesley. ISBN 0-13-142901-9.
 - [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.
-  'DocBook - The Definitive Guide'. O'Reilly & Associates.
-  1999. ISBN 1-56592-580-7.
+  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999. 
+  ISBN 1-56592-580-7.
 ---------------------------------------------------------------------
 
 The `[[[<reference>]]]` syntax is a bibliography entry anchor, it


### PR DESCRIPTION
Fix documentation about bibliography

As pointed by matt at: https://groups.google.com/forum/?fromgroups=#!topic/asciidoc/Toebf1FFYd0

I tested and it's there:

$ cat bibtest.txt 
== Text

Some text.

[bibliography]
.Optional list title
- [[[taoup]]] Eric Steven Raymond. 'The Art of UNIX
  Programming'. Addison-Wesley. ISBN 0-13-142901-9.
- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.
  'DocBook - The Definitive Guide'. O'Reilly & Associates.
  1. ISBN 1-56592-580-7.

$ asciidoc bibtest.txt 
asciidoc: WARNING: bibtest.txt: line 11: list item index: expected 1 got 1999
