### PR TITLE
Modified the way the command string is constructed for calling the text-...

### DIFF
--- a/a2x.py
+++ b/a2x.py
@@ -45,8 +45,8 @@ ASCIIDOC = 'asciidoc'
 XSLTPROC = 'xsltproc'
 DBLATEX = 'dblatex'         # pdf generation.
 FOP = 'fop'                 # pdf generation (--fop option).
-W3M = 'w3m'                 # text generation.
-LYNX = 'lynx'               # text generation (if no w3m).
+W3M = 'w3m'                 # primary text file generator.
+LYNX = 'lynx'               # alternate text file generator.
 XMLLINT = 'xmllint'         # Set to '' to disable.
 EPUBCHECK = 'epubcheck'     # Set to '' to disable.
 # External executable default options.
@@ -54,8 +54,8 @@ ASCIIDOC_OPTS = ''
 BACKEND_OPTS = ''
 DBLATEX_OPTS = ''
 FOP_OPTS = ''
-LYNX_OPTS = ''
-W3M_OPTS = '-cols 70 -T text/html -no-graph'
+LYNX_OPTS = '-dump'
+W3M_OPTS = '-dump -cols 70 -T text/html -no-graph'
 XSLTPROC_OPTS = ''
 
 ######################################################################
@@ -821,7 +821,7 @@ class A2X(AttrDict):
             shell('"%s" %s --conf-file "%s" -b html4 -a "a2x-format=%s" -o "%s" "%s"' %
                  (self.asciidoc, self.asciidoc_opts, self.asciidoc_conf_file('text.conf'),
                   self.format, html_file, self.asciidoc_file))
-            cmd = '"%s" -dump %s "%s" > "%s"' % (LYNX, LYNX_OPTS, html_file, text_file)
+            cmd = '"%s" %s "%s" > "%s"' % (LYNX, LYNX_OPTS, html_file, text_file)
             shell(cmd)
         else:
             # Use w3m(1).
@@ -830,7 +830,7 @@ class A2X(AttrDict):
             opts = '%s --output "%s"' % (self.xsltproc_opts, html_file)
             exec_xsltproc(self.xsl_stylesheet(), docbook_file,
                     self.destination_dir, opts)
-            cmd = '"%s" -dump %s "%s" > "%s"' % (W3M, W3M_OPTS, html_file, text_file)
+            cmd = '"%s" %s "%s" > "%s"' % (W3M, W3M_OPTS, html_file, text_file)
             shell(cmd)
         if not self.keep_artifacts:
             shell_rm(html_file)

--- a/a2x.py
+++ b/a2x.py
@@ -51,10 +51,12 @@ XMLLINT = 'xmllint'         # Set to '' to disable.
 EPUBCHECK = 'epubcheck'     # Set to '' to disable.
 # External executable default options.
 ASCIIDOC_OPTS = ''
+BACKEND_OPTS = ''
 DBLATEX_OPTS = ''
 FOP_OPTS = ''
+LYNX_OPTS = ''
+W3M_OPTS = '-cols 70 -T text/html -no-graph'
 XSLTPROC_OPTS = ''
-BACKEND_OPTS = ''
 
 ######################################################################
 # End of configuration file parameters.
@@ -819,7 +821,7 @@ class A2X(AttrDict):
             shell('"%s" %s --conf-file "%s" -b html4 -a "a2x-format=%s" -o "%s" "%s"' %
                  (self.asciidoc, self.asciidoc_opts, self.asciidoc_conf_file('text.conf'),
                   self.format, html_file, self.asciidoc_file))
-            cmd = "%s -dump " '"%s" > "%s"' % (LYNX, html_file, text_file)
+            cmd = '"%s" -dump %s "%s" > "%s"' % (LYNX, LYNX_OPTS, html_file, text_file)
             shell(cmd)
         else:
             # Use w3m(1).
@@ -828,7 +830,7 @@ class A2X(AttrDict):
             opts = '%s --output "%s"' % (self.xsltproc_opts, html_file)
             exec_xsltproc(self.xsl_stylesheet(), docbook_file,
                     self.destination_dir, opts)
-            cmd = "%s -dump -T text/html -no-graph " '"%s" > "%s"' % (W3M, html_file, text_file)
+            cmd = '"%s" -dump %s "%s" > "%s"' % (W3M, W3M_OPTS, html_file, text_file)
             shell(cmd)
         if not self.keep_artifacts:
             shell_rm(html_file)

--- a/a2x.py
+++ b/a2x.py
@@ -819,8 +819,8 @@ class A2X(AttrDict):
             shell('"%s" %s --conf-file "%s" -b html4 -a "a2x-format=%s" -o "%s" "%s"' %
                  (self.asciidoc, self.asciidoc_opts, self.asciidoc_conf_file('text.conf'),
                   self.format, html_file, self.asciidoc_file))
-            shell('"%s" -dump "%s" > "%s"' %
-                 (LYNX, html_file, text_file))
+            cmd = "%s -dump %s > %s" % (LYNX, html_file, text_file)
+            shell(cmd)
         else:
             # Use w3m(1).
             self.to_docbook()
@@ -828,8 +828,8 @@ class A2X(AttrDict):
             opts = '%s --output "%s"' % (self.xsltproc_opts, html_file)
             exec_xsltproc(self.xsl_stylesheet(), docbook_file,
                     self.destination_dir, opts)
-            shell('"%s" -cols 70 -dump -T text/html -no-graph "%s" > "%s"' %
-                 (W3M, html_file, text_file))
+            cmd = "%s -dump -T text/html -no-graph %s > %s" % (W3M, html_file, text_file)
+            shell(cmd)
         if not self.keep_artifacts:
             shell_rm(html_file)
 

--- a/a2x.py
+++ b/a2x.py
@@ -819,7 +819,7 @@ class A2X(AttrDict):
             shell('"%s" %s --conf-file "%s" -b html4 -a "a2x-format=%s" -o "%s" "%s"' %
                  (self.asciidoc, self.asciidoc_opts, self.asciidoc_conf_file('text.conf'),
                   self.format, html_file, self.asciidoc_file))
-            cmd = "%s -dump %s > %s" % (LYNX, html_file, text_file)
+            cmd = "%s -dump " '"%s" > "%s"' % (LYNX, html_file, text_file)
             shell(cmd)
         else:
             # Use w3m(1).
@@ -828,7 +828,7 @@ class A2X(AttrDict):
             opts = '%s --output "%s"' % (self.xsltproc_opts, html_file)
             exec_xsltproc(self.xsl_stylesheet(), docbook_file,
                     self.destination_dir, opts)
-            cmd = "%s -dump -T text/html -no-graph %s > %s" % (W3M, html_file, text_file)
+            cmd = "%s -dump -T text/html -no-graph " '"%s" > "%s"' % (W3M, html_file, text_file)
             shell(cmd)
         if not self.keep_artifacts:
             shell_rm(html_file)

--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -49,8 +49,8 @@ OPTIONS
 
 *-b, --backend*='BACKEND'::
   'BACKEND' is the name of an installed backend plugin. When this
-  option is specified 'a2x' attempts load a file name 'a2x-backend.py'
-  from the 'BACKEND' plugin directory It then converts the
+  option is specified 'a2x' attempts to load a file name 'a2x-backend.py'
+  from the 'BACKEND' plugin directory. It then converts the
   'SOURCE_FILE' to a 'BACKEND' formatted output file using a global
   function defined in 'a2x-backend.py' called 'to_BACKEND'.
 
@@ -75,8 +75,10 @@ OPTIONS
   Do not delete temporary build files.
 
 *--lynx*::
-  Use 'lynx(1)' to generate text formatted output. The default
-  behavior is to use 'w3m(1)'.
+  Use 'lynx(1)' (actually: the text-based browser defined by the `LYNX` config
+  variable) when generating text formatted output. The default behavior is to
+  use 'w3m(1)' (actually: the text-based browser defined by the `W3M` config
+  variable).
 
 *-L, --no-xmllint*::
   Do not check asciidoc output with 'xmllint(1)'.
@@ -323,16 +325,27 @@ ASCIIDOC = 'asciidoc'
 XSLTPROC = 'xsltproc'
 DBLATEX = 'dblatex'         # pdf generation.
 FOP = 'fop'                 # pdf generation (--fop option).
-W3M = 'w3m'                 # text generation.
-LYNX = 'lynx'               # text generation (if no w3m).
+W3M = 'w3m'                 # primary text file generator.
+LYNX = 'lynx'               # alternate text file generator.
 XMLLINT = 'xmllint'         # Set to '' to disable.
 EPUBCHECK = 'epubcheck'     # Set to '' to disable.
 # External executable default options.
 ASCIIDOC_OPTS = ''
+BACKEND_OPTS = ''
 DBLATEX_OPTS = ''
 FOP_OPTS = ''
+LYNX_OPTS = '-dump'
+W3M_OPTS = '-dump -cols 70 -T text/html -no-graph'
 XSLTPROC_OPTS = ''
 ---------------------------------------------------------------------
+
+Note, that it is possible to redefine `W3M` and `LYNX` to use different text-based
+browsers, e.g. 'links': http://links.twibright.com/ or
+'elinks': http://elinks.or.cz/. `LYNX_OPTS` and `W3M_OPTS` can be used to pass
+options to the selected browser. If these are defined they override the
+respective defaults listed above (so don't forget to include the '-dump' option
+in your definition: this is mandatory at least with 'w3m', 'lynx', 'links', and
+'elinks' in order to send the formatted text to stdout).
 
 
 BUGS


### PR DESCRIPTION
...based browsers (w3m, lynx, etc.).
this fixes the previously existing limitation that it was not possible to pass any arguments to the selected text-based browser by defining an entry in `a2x.conf' such as

LYNX = "elinks -dump-width 80"

moreover, the old call for `w3m' (the default) _did_ explicitly set  a (rather small) width. I removed this setting so that behaviour is more consistent (specify width always explicitly, if desired, for the selected browser (defined via W3M or LYNX) or accept the default width used by that browser.
