### PR TITLE
"Errors should never pass silently"

### DIFF
--- a/doc/testasciidoc.txt
+++ b/doc/testasciidoc.txt
@@ -171,6 +171,9 @@ Optional list of command-line option tuples.
 % attributes
 Optional dictionary of attribute values.
 
+% messages
+Optional list of expected messages
+
 ---------------------------------------------------------------------
 
 Example test spec:
@@ -209,6 +212,10 @@ configuration file that comes with AsciiDoc.
   equivalent to a `(name,None)` tuple.
 - The 'attributes' directive data specifies a Python dictionary
   containing AsciiDoc attributes to be passed to AsciiDoc.
+- The 'messages' directive is a list of messages expected on the
+  screen.  The format is `WARNING: something goes wrong` where
+  filename and line number are omitted.  Unexpected messages will
+  be reported as warnings in the test report.
 
 globals directive
 ~~~~~~~~~~~~~~~~~

--- a/docbook45.conf
+++ b/docbook45.conf
@@ -92,6 +92,9 @@ latexmath-style=template="latexmathblock",subs=()
 {title#}</figure>
 {title%}</informalfigure>
 
+[unfloat-blockmacro]
+# nothing to see here
+
 [indexterm-inlinemacro]
 # Index term.
 # Generate separate index entries for primary, secondary and tertiary

--- a/filters/latex/latex2img.py
+++ b/filters/latex/latex2img.py
@@ -224,7 +224,7 @@ def main():
     if dpi and not dpi.isdigit():
         usage('invalid DPI')
         sys.exit(1)
-    if not imgfmt in {'png', 'svg'}:
+    if imgfmt not in ('png', 'svg'):
         usage('Invalid image format. Valid values are "png" or "svg".')
         sys.exit(1)
     if outfile is None:

--- a/tests/testasciidoc.conf
+++ b/tests/testasciidoc.conf
@@ -9,6 +9,9 @@ Test cases
 % source
 data/testcases.txt
 
+% messages
+WARNING: nested inline passthrough
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Filters
 
@@ -26,6 +29,9 @@ Old tables
 
 % source
 data/oldtables.txt
+
+% messages
+DEPRECATED: old tables syntax
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Source highlighter
@@ -775,6 +781,9 @@ UTF-8 BOM test
 
 % source
 data/utf8-bom-test.txt
+
+% messages
+WARNING: maximum include depth exceeded
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Deprecated quote attributes

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -207,13 +207,14 @@ class AsciiDocTest(object):
         outfile = StringIO.StringIO()
         asciidoc.execute(infile, outfile, backend)
         has_warnings = asciidoc.asciidoc.document.has_warnings
-        return outfile.getvalue().splitlines(), has_warnings
+        messages = asciidoc.messages
+        return outfile.getvalue().splitlines(), has_warnings, messages
 
     def update_expected(self, backend):
         """
         Generate and write backend data.
         """
-        lines, has_warnings = self.generate_expected(backend)
+        lines, __, __ = self.generate_expected(backend)
         if not os.path.isdir(self.datadir):
             print('CREATING: %s' % self.datadir)
             os.mkdir(self.datadir)
@@ -255,8 +256,10 @@ class AsciiDocTest(object):
                 if not self.is_missing(backend):
                     expected = self.get_expected(backend)
                     strip_end(expected)
-                    got, has_warnings = self.generate_expected(backend)
+                    got, has_warnings, msgs = self.generate_expected(backend)
                     strip_end(got)
+                    for message in msgs:
+                        print('  %s' % message)
                     lines = []
                     for line in difflib.unified_diff(got, expected, n=0):
                         lines.append(line)


### PR DESCRIPTION
> _Errors should never pass silently_ - [The Zen of Python](https://www.python.org/dev/peps/pep-0020/)

This pull request is based on the previous one #25. It improves the `testasciidoc.py` tool to report better the failures and the other warnings.
I recommend to review and merge #25 before considering this one.
https://github.com/florentx/asciidoc/compare/with-travis...compat26

When preparing PR #25 I discovered that the test suite is a bit too indulgent:
- if some dependency is missing, errors are printed but test is marked PASSED
- if a filter spawns a subprocess and it crashes, test is marked PASSED
- if the source of a test was deleted or a backend is missing, the test is SKIPPED but the exit code is 0
- if a macro or anything else returns a warning, the warning is silenced, and result is PASSED

This PR addresses the above issues:
- it returns exit code 1 on FAILED tests, but also on SKIPPED tests, and on warnings too
- it prints all the unexpected messages on the screen when running the test suite
- a new directive is created for `testasciidoc.conf` to declare the expected messages: `% messages`
- this new directive is documented
- test is counted as WARNED if some message is unexpected, and the exit code is set to 1

I've chosen to add all the current warnings to the expected `% messages`, so the Travis-CI build is still green after the merge.
However, we should challenge this in the future, and probably fix some tests.
