### PR TITLE
Use standard sys.exit() instead of the fragile exit from site.py module

### DIFF
--- a/a2x.py
+++ b/a2x.py
@@ -962,4 +962,4 @@ if __name__ == '__main__':
         a2x.load_conf()
         a2x.execute()
     except KeyboardInterrupt:
-        exit(1)
+        sys.exit(1)

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -411,7 +411,7 @@ if __name__ == '__main__':
     if cmd == 'run':
         tests.run(number, backend)
         if tests.failed:
-            exit(1)
+            sys.exit(1)
     elif cmd == 'update':
         tests.update(number, backend, force=force)
     elif cmd == 'list':


### PR DESCRIPTION
Rationale:

``` bash
$ python -c 'print(type(exit))'
<class 'site.Quitter'>
$ python -Sc 'type(exit)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'exit' is not defined
```
