### PR TITLE
Generate stable test output

### DIFF
--- a/filters/source/source-highlight-filter.conf
+++ b/filters/source/source-highlight-filter.conf
@@ -58,7 +58,7 @@ endif::basebackend-docbook[]
 ifdef::basebackend-html[]
 [source-filter-style]
 ifeval::["{source-highlighter}"=="source-highlight"]
-source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="source-highlight -f xhtml -s {language} {src_numbered?--line-number=' '} {src_tab?--tab={src_tab}} {args=}"
+source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="source-highlight --gen-version -f xhtml -s {language} {src_numbered?--line-number=' '} {src_tab?--tab={src_tab}} {args=}"
 endif::[]
 ifeval::["{source-highlighter}"=="highlight"]
 source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="highlight --no-doc --inline-css --out-format=xhtml --syntax={language@python:py:{language}} {src_numbered?--line-number} {src_tab?--tab={src_tab}} --encoding={encoding} {args=}"
@@ -76,7 +76,7 @@ ifdef::basebackend-html4[]
 [source-filter-style]
 # html4 does not use pygments.
 ifeval::["{source-highlighter}"=="source-highlight"]
-source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="source-highlight -f html -s {language} {src_numbered?--line-number=' '} {src_tab?--tab={src_tab}} {args=}"
+source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="source-highlight --gen-version -f html -s {language} {src_numbered?--line-number=' '} {src_tab?--tab={src_tab}} {args=}"
 endif::[]
 ifeval::["{source-highlighter}"=="highlight"]
 source-style=template="source-highlight-block",presubs=(),postsubs=("callouts",),posattrs=("style","language","src_numbered","src_tab"),filter="highlight --no-doc --inline-css --out-format=html --syntax={language@python:py:{language}} {src_numbered?--line-number} {src_tab?--tab={src_tab}} {args=}"

--- a/tests/data/barchart.py
+++ b/tests/data/barchart.py
@@ -1,0 +1,2 @@
+print("No barchart to avoid depending on Pychart for the tests.\n"
+      "See also: http://asciidoc.org/faq.html#_is_it_possible_to_include_charts_in_asciidoc_documents")

--- a/tests/data/utf8-bom-test.txt
+++ b/tests/data/utf8-bom-test.txt
@@ -4,6 +4,6 @@
 Include file with UTF-8 BOM:
 
 :leveloffset: 1
-include::{docfile}[depth=1]
+include::{docname}.txt[depth=1]
 
 Lorum ipsum...

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -107,7 +107,7 @@ class AsciiDocTest(object):
         self.description = []   # List of lines followoing title.
         self.source = None      # AsciiDoc test source file name.
         self.options = []
-        self.attributes = {}
+        self.attributes = {'asciidoc-version': 'test'}
         self.backends = BACKENDS
         self.datadir = None     # Where output files are stored.
         self.disabled = False
@@ -156,7 +156,7 @@ class AsciiDocTest(object):
                         if isinstance(v, basestring):
                             self.options[i] = (v,None)
                 elif directive == 'attributes':
-                    self.attributes = eval(' '.join(data))
+                    self.attributes.update(eval(' '.join(data)))
                 elif directive == 'backends':
                     self.backends = eval(' '.join(data))
                 elif directive == 'name':

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -22,6 +22,7 @@ __copyright__ = 'Copyright (C) 2009 Stuart Rackham'
 
 
 import os, sys, re, difflib
+import time
 
 if sys.platform[:4] == 'java':
     # Jython cStringIO is more compatible with CPython StringIO.
@@ -73,6 +74,28 @@ def normalize_data(lines):
     result = [ s for s in lines if not s.startswith('#') ]
     strip_end(result)
     return result
+
+
+def mock_localtime(f, _localtime=time.localtime):
+    """Mock time module to generate stable output."""
+    _frozentime = 0X3DE170D6
+    _frozentz = 'Pacific/Auckland'
+
+    def _frozen_localtime(t=_frozentime + 1):
+        assert t > _frozentime, 'File created before first public release'
+        return _localtime(_frozentime)
+
+    def generate_expected(self, backend):
+        time.localtime = _frozen_localtime
+        os.environ['TZ'] = _frozentz
+        time.tzset()
+        try:
+            return f(self, backend)
+        finally:
+            time.localtime = _localtime
+            del os.environ['TZ']
+            time.tzset()
+    return generate_expected
 
 
 class AsciiDocTest(object):
@@ -172,6 +195,7 @@ class AsciiDocTest(object):
             f.close()
         return result
 
+    @mock_localtime
     def generate_expected(self, backend):
         """
         Generate and return test data output for backend.


### PR DESCRIPTION
Currently the output of the tests is not stable when running in different environments:
- some absolute file paths are printed, which depend on the path of the build directory
- `Last updated` timestamp is printed in the output of many tests

This PR removes the above glitches. It is a prerequisite for fixing issue #30

Details of the changes:
- florentx@1c49ffe patches the `time.localtime` function and the `TZ` environment variable which are used to generate the `Last updated` timestamp
- florentx@b3fb9cc adds a stub `barchart.py` file to avoid printing an error message with the absolute path of the missing file
- florentx@f4c5f46 replaces absolute path `{docfile}` with relative path `{docname}.txt`
