### PR TITLE
Do not depend on deprecated md5

### DIFF
--- a/filters/latex/latex2img.py
+++ b/filters/latex/latex2img.py
@@ -58,11 +58,10 @@ COPYING
     granted under the terms of the MIT License.
 '''
 
-# Suppress warning: "the md5 module is deprecated; use hashlib instead"
-import warnings
-warnings.simplefilter('ignore',DeprecationWarning)
-
-import os, sys, tempfile, md5
+import hashlib
+import os
+import sys
+import tempfile
 
 VERSION = '0.2.0'
 
@@ -132,7 +131,7 @@ def latex2img(infile, outfile, imgfmt, dpi, modified):
     if infile == '-':
         tex = sys.stdin.read()
         if modified:
-            checksum = md5.new(tex + imgfmt + str(dpi)).digest()
+            checksum = hashlib.md5(tex + imgfmt + str(dpi)).digest()
             md5_file = os.path.splitext(outfile)[0] + '.md5'
             if os.path.isfile(md5_file) and os.path.isfile(outfile) and \
                     checksum == read_file(md5_file,'rb'):

--- a/filters/music/music2png.py
+++ b/filters/music/music2png.py
@@ -50,11 +50,10 @@ COPYING
     granted under the terms of the GNU General Public License (GPL).
 '''
 
-# Suppress warning: "the md5 module is deprecated; use hashlib instead"
-import warnings
-warnings.simplefilter('ignore',DeprecationWarning)
-
-import os, sys, tempfile, md5
+import hashlib
+import os
+import sys
+import tempfile
 
 VERSION = '0.1.2'
 
@@ -103,7 +102,7 @@ def music2png(format, infile, outfile, modified):
     skip = False
     if infile == '-':
         source = sys.stdin.read()
-        checksum = md5.new(source).digest()
+        checksum = hashlib.md5(source).digest()
         filename = os.path.splitext(outfile)[0] + '.md5'
         if modified:
             if os.path.isfile(filename) and os.path.isfile(outfile) and \


### PR DESCRIPTION
Change the filters `latex` and `music` to avoid depending on a deprecated module.

Module `hashlib` exists since Python 2.5.
https://docs.python.org/2/library/hashlib.html
