### PR TITLE
Add a link to AsciiDocBox in the website.

### DIFF
--- a/examples/website/index.txt
+++ b/examples/website/index.txt
@@ -204,9 +204,8 @@ image::images/highlighter.png[height=400,caption="",link="images/highlighter.png
 
 Try AsciiDoc on the Web
 -----------------------
-Andrew Koster has written a Web based application to interactively
-convert and display AsciiDoc source:
-http://andrewk.webfactional.com/asciidoc.php
+Thaddée Tyl has written an online live editor to try AsciiDoc in your browser:
+http://espadrine.github.io/AsciiDocBox/
 
 
 [[X2]]


### PR DESCRIPTION
The [other](http://andrewk.webfactional.com/asciidoc.php) live editor linked to from the [website](http://asciidoc.org/) is deactivated, which prompted me to create [AsciiDocBox](http://espadrine.github.io/AsciiDocBox/). This pull request adds a link to that "try AsciiDoc in your browser" website.

This is [the thread](https://groups.google.com/forum/#!topic/asciidoc/oezXYezBMgs) introducing AsciiDocBox.
