### PR TITLE
dblatex and backticks inside a listing block

### DIFF
--- a/dblatex/asciidoc-dblatex.sty
+++ b/dblatex/asciidoc-dblatex.sty
@@ -18,3 +18,5 @@
 
 % For DocBook literallayout elements, see `./dblatex/dblatex-readme.txt`.
 \usepackage{alltt}
+% To preserve simple quotes in the blocs of code
+\usepackage{upquote}


### PR DESCRIPTION
Hi,

When using simple quotes in a listing/code block with dblatex generates some strange quotes you cannot copy/paste as is.
Adding the package 'upquote' in style file preserves correct quotes in code blocs.

Please refer to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=752455 for more details.

Best,
Joseph
