### PR TITLE
Embedded image corruption fix

### DIFF
--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -80,7 +80,8 @@ latexmath-style=template="latexmathblock",subs=()
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,';"}
+{data-uri#}{sys3:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </span>
 


### PR DESCRIPTION
When using xhmtl11 and embedded images the base64 data would sometime get
corrupted when patterns like '++++' would be turned to '+'

Change-Id: I701ff72d5e0616947af2d4f06fea3406506f98a4
