### PR TITLE
Fix A2X directory warning

### DIFF
--- a/a2x.py
+++ b/a2x.py
@@ -458,7 +458,7 @@ class A2X(AttrDict):
                 die('missing --destination-dir: %s' % self.destination_dir)
             self.destination_dir = os.path.abspath(self.destination_dir)
             if not self.format in ('chunked','epub','htmlhelp','xhtml','manpage'):
-                warning('--destination-dir option is only applicable to HTML based outputs')
+                warning('--destination-dir option is only applicable to HTML and manpage based outputs')
         self.resource_dirs = []
         self.resource_files = []
         if self.resource_manifest:

--- a/a2x.py
+++ b/a2x.py
@@ -457,7 +457,7 @@ class A2X(AttrDict):
             if not os.path.isdir(self.destination_dir):
                 die('missing --destination-dir: %s' % self.destination_dir)
             self.destination_dir = os.path.abspath(self.destination_dir)
-            if not self.format in ('chunked','epub','htmlhelp','xhtml'):
+            if not self.format in ('chunked','epub','htmlhelp','xhtml','manpage'):
                 warning('--destination-dir option is only applicable to HTML based outputs')
         self.resource_dirs = []
         self.resource_files = []

--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -39,8 +39,8 @@ OPTIONS
 
 *-D, --destination-dir*='DESTINATION_DIR'::
   Output directory. Defaults to 'SOURCE_FILE' directory. This option
-  is only applicable to HTML based output formats ('chunked', 'epub',
-  'htmlhelp', 'xhtml').
+  is only applicable to HTML and manpage based output formats ('chunked', 'epub',
+  'htmlhelp', 'xhtml', 'manpage').
 
 *-d, --doctype*='DOCTYPE'::
   DocBook document type: 'article', 'manpage' or 'book'.  Default


### PR DESCRIPTION
Fix issue #44. The a2x --destination-dir warning is fixed by adding
'manpage' as an option to the condition check on line 460.
