### PR TITLE
Fix and enhance en/em dash translation

### DIFF
--- a/asciidoc.conf
+++ b/asciidoc.conf
@@ -52,6 +52,7 @@ lsquo=&#8216;
 rsquo=&#8217;
 ldquo=&#8220;
 rdquo=&#8221;
+compat-mode=
 
 [titles]
 subs=specialcharacters,quotes,replacements,macros,attributes,replacements2
@@ -123,6 +124,22 @@ monospacedwords=
 (\n-- )|( -- )|( --\n)=&#8201;&#8212;&#8201;
 (\w)--(\w)=\1&#8212;\2
 \\--(?!-)=--
+
+ifndef::compat-mode[]
+# --- Spaced and unspaced em dashes (entity reference &mdash;).
+# Space on both sides is translated to thin space characters.
+(^--- )=&#8212;&#8201;
+(\n--- )|( --- )|( ---\n)=&#8201;&#8212;&#8201;
+(\w)---(\w)=\1&#8212;\2
+\\---(?!-)=---
+
+# -- Spaced and unspaced en dashes (entity reference &ndash;).
+# Space on both sides is translated to thin space characters.
+(^-- )=&#8211;&#8201;
+(\n-- )|( -- )|( --\n)=&#8201;&#8211;&#8201;
+(\w)--(\w)=\1&#8211;\2
+\\--(?!-)=--
+endif::compat-mode[]
 
 # Replace vertical typewriter apostrophe with punctuation apostrophe.
 (\w)'(\w)=\1&#8217;\2

--- a/latex.conf
+++ b/latex.conf
@@ -70,7 +70,10 @@ _=\_{}
 # Line break.
 (?m)^(.*)\s\+$=\1 !..backslash..!newline!..braceleft..!!..braceright..!
 
-# -- Spaced em dashes (entity reference &mdash;)
+# --- Spaced em dashes (entity reference &mdash;)
+(^|[^-\\])---($|[^-])=\1---\2
+
+# -- Spaced en dashes (entity reference &ndash;)
 (^|[^-\\])--($|[^-])=\1--\2
 
 


### PR DESCRIPTION
Depending on the back-end being used, `--` gets currently translated either to an em dash (HTML, for instance) or an en dash (LaTeX). To allow convenient usage of both types of dashes and resolve this inconsistency, translate (in sync with LaTeX) `--` to en dash and `---` to em dash.

Well, this will "break" existing documents, of course—the AsciiDoc user guide, for instance.
