### PR TITLE
Vim syntax file: sub/superscript like other quoted

### DIFF
--- a/vim/syntax/asciidoc.vim
+++ b/vim/syntax/asciidoc.vim
@@ -44,8 +44,8 @@ syn match asciidocAttributeRef /\\\@<!{\w\(\w\|[-,+]\)*\([=!@#$%?:].*\)\?}/
 " As a damage control measure quoted patterns always terminate at a blank
 " line (see 'Limitations' above).
 syn match asciidocQuotedAttributeList /\\\@<!\[[a-zA-Z0-9_-][a-zA-Z0-9 _-]*\][+_'`#*]\@=/
-syn match asciidocQuotedSubscript /\\\@<!\~\S\_.\{-}\(\~\|\n\s*\n\)/ contains=asciidocEntityRef
-syn match asciidocQuotedSuperscript /\\\@<!\^\S\_.\{-}\(\^\|\n\s*\n\)/ contains=asciidocEntityRef
+syn match asciidocQuotedSubscript /\(^\|[-–—−~^+`'*| \t([.,=\]]\)\@<=\~\([~ \n\t]\)\@!\(.\|\n\(\s*\n\)\@!\)\{-}\S\(\~\([-–—−~^+`'*| \t)[\],.?!;:=]\|$\)\@=\)/ contains=asciidocEntityRef
+syn match asciidocQuotedSuperscript /\(^\|[-–—−~^+`'*| \t([.,=\]]\)\@<=\^\([\^ \n\t]\)\@!\(.\|\n\(\s*\n\)\@!\)\{-}\S\(\^\([-–—−~^+`'*| \t)[\],.?!;:=]\|$\)\@=\)/ contains=asciidocEntityRef
 
 syn match asciidocQuotedMonospaced /\(^\|[| \t([.,=\]]\)\@<=+\([+ \n\t]\)\@!\(.\|\n\(\s*\n\)\@!\)\{-}\S\(+\([| \t)[\],.?!;:=]\|$\)\@=\)/ contains=asciidocEntityRef
 syn match asciidocQuotedMonospaced2 /\(^\|[| \t([.,=\]]\)\@<=`\([` \n\t]\)\@!\(.\|\n\(\s*\n\)\@!\)\{-}\S\(`\([| \t)[\],.?!;:=]\|$\)\@=\)/


### PR DESCRIPTION
Example for testing (patch fix everything marked "Wrong"):

```
- Right: Some~ text
- Right: Here ~another text
  too~
- Wrong: Some ~text

Right:: definition

*Right*:: definition
    'Right';; definition

~Right~:: definition
    ^Right^;; definition

~Wrong:: definition
    ^Wrong;; definition
```
