### PR TITLE
Vim syntax file: highlight quoted delimiters

### DIFF
--- a/vim/syntax/asciidoc.vim
+++ b/vim/syntax/asciidoc.vim
@@ -66,6 +66,17 @@ syn match asciidocQuotedDoubleQuoted /\(^\|[| \t([.,=\]]\)\@<=``\([` \n\t]\)\@!\
 syn match asciidocDoubleDollarPassthrough /\\\@<!\(^\|[^0-9a-zA-Z$]\)\@<=\$\$..\{-}\(\$\$\([^0-9a-zA-Z$]\|$\)\@=\|^$\)/
 syn match asciidocTriplePlusPassthrough /\\\@<!\(^\|[^0-9a-zA-Z$]\)\@<=+++..\{-}\(+++\([^0-9a-zA-Z$]\|$\)\@=\|^$\)/
 
+syn match asciidocSubscriptDelimiter contained "[~]" containedin=asciidocQuotedSubscript
+syn match asciidocSuperscriptDelimiter contained "\^" containedin=asciidocQuotedSuperscript
+syn match asciidocMonospacedDelimiter contained "[+]" containedin=asciidocQuotedMonospaced
+syn match asciidocMonospaced2Delimiter contained "[`]" containedin=asciidocQuotedMonospaced2
+syn match asciidocUnconstrainedMonospacedDelimiter contained "[+][+]" containedin=asciidocQuotedUnconstrainedMonospaced
+syn match asciidocEmphasizedDelimiter contained "[_]" containedin=asciidocQuotedEmphasized
+syn match asciidocEmphasized2Delimiter contained "[']" containedin=asciidocQuotedEmphasized2
+syn match asciidocUnconstrainedEmphasizedDelimiter contained "[_][_]" containedin=asciidocQuotedUnconstrainedEmphasized
+syn match asciidocBoldDelimiter contained "[*]" containedin=asciidocQuotedBold
+syn match asciidocUnconstrainedBoldDelimiter contained "[*][*]" containedin=asciidocQuotedUnconstrainedBold
+
 syn match asciidocAdmonition /^\u\{3,15}:\(\s\+.*\)\@=/
 
 syn region asciidocTable_OLD start=/^\([`.']\d*[-~_]*\)\+[-~_]\+\d*$/ end=/^$/
@@ -164,6 +175,16 @@ hi def link asciidocQuotedSuperscript Type
 hi def link asciidocQuotedUnconstrainedBold Special
 hi def link asciidocQuotedUnconstrainedEmphasized Type
 hi def link asciidocQuotedUnconstrainedMonospaced Identifier
+hi def link asciidocSubscriptDelimiter asciidocQuotedSubscript
+hi def link asciidocSuperscriptDelimiter asciidocQuotedSuperscript
+hi def link asciidocMonospacedDelimiter asciidocQuotedMonospaced
+hi def link asciidocMonospaced2Delimiter asciidocQuotedMonospaced2
+hi def link asciidocUnconstrainedMonospacedDelimiter asciidocQuotedUnconstrainedMonospaced
+hi def link asciidocEmphasizedDelimiter asciidocQuotedEmphasized
+hi def link asciidocEmphasized2Delimiter asciidocQuotedEmphasized2
+hi def link asciidocUnconstrainedEmphasizedDelimiter asciidocQuotedUnconstrainedEmphasized
+hi def link asciidocBoldDelimiter asciidocQuotedBold
+hi def link asciidocUnconstrainedBoldDelimiter asciidocQuotedUnconstrainedBold
 hi def link asciidocRefMacro Macro
 hi def link asciidocRuler Type
 hi def link asciidocSidebarDelimiter Type


### PR DESCRIPTION
Add (optional) ability to highlight quoted delimiters. To use it change from default (same as quoted content) to something else (like SpecialChar):

```
:hi link asciidocSubscriptDelimiter SpecialChar
:hi link asciidocSuperscriptDelimiter SpecialChar
:hi link asciidocMonospacedDelimiter SpecialChar
:hi link asciidocMonospaced2Delimiter SpecialChar
:hi link asciidocUnconstrainedMonospacedDelimiter SpecialChar
:hi link asciidocEmphasizedDelimiter SpecialChar
:hi link asciidocEmphasized2Delimiter SpecialChar
:hi link asciidocUnconstrainedEmphasizedDelimiter SpecialChar
:hi link asciidocBoldDelimiter SpecialChar
:hi link asciidocUnconstrainedBoldDelimiter SpecialChar
```

Test using:

```
- Example: ~sub~ ^super^
- Example: +mono+ `mono2` X++umono++X
- Example: _em_ 'em2' X__uem__X
- Example: *bold* X**ubold**X
```
