### PR TITLE
Update build files to as latex2png was renamed to latex2img

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -52,7 +52,7 @@ filters/code/code-filter.conf
 filters/code/code-filter.py
 filters/code/code-filter-readme.txt
 filters/code/code-filter-test.txt
-filters/latex/latex2png.py
+filters/latex/latex2img.py
 filters/latex/latex-filter.conf
 filters/music/music-filter.conf
 filters/music/music2png.py

--- a/Makefile.in
+++ b/Makefile.in
@@ -53,7 +53,7 @@ musicfilterconfdir = $(filtersdir)/music
 sourcefilterconf = filters/source/source-highlight-filter.conf
 sourcefilterconfdir = $(filtersdir)/source
 
-latexfilter = filters/latex/latex2png.py
+latexfilter = filters/latex/latex2img.py
 latexfilterdir = $(filtersdir)/latex
 latexfilterconf = filters/latex/latex-filter.conf
 latexfilterconfdir = $(filtersdir)/latex


### PR DESCRIPTION
Since https://github.com/asciidoc/asciidoc/commit/1ee5ed35de7b9a7a9652f3492e0ba2dbc2509c78 the latex2png.py was renamed to latex2img.py, however the build scripts were never updated.
