### PR TITLE
New setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ tests/data/*.png
 # ignore doc products
 doc/*.md5
 doc/*.ly
+
+build/
+dist/

--- a/Makefile.in
+++ b/Makefile.in
@@ -53,7 +53,7 @@ musicfilterconfdir = $(filtersdir)/music
 sourcefilterconf = filters/source/source-highlight-filter.conf
 sourcefilterconfdir = $(filtersdir)/source
 
-latexfilter = filters/latex/latex2png.py
+latexfilter = filters/latex/latex2img.py
 latexfilterdir = $(filtersdir)/latex
 latexfilterconf = filters/latex/latex-filter.conf
 latexfilterconfdir = $(filtersdir)/latex

--- a/asciidoc.bat
+++ b/asciidoc.bat
@@ -1,0 +1,2 @@
+echo %~$PATH:0\..\python.exe
+"%~$PATH:0\..\python.exe" "%~$PATH:0\..\Scripts\%~n0.py" %*

--- a/doc/a2x.1
+++ b/doc/a2x.1
@@ -1,0 +1,747 @@
+'\" t
+.\"     Title: a2x
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
+.\"      Date: 04/11/2015
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "A2X" "1" "04/11/2015" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+a2x \- A toolchain manager for AsciiDoc (converts Asciidoc text files to other file formats)
+.SH "SYNOPSIS"
+.sp
+\fBa2x\fR [\fIOPTIONS\fR] \fISOURCE_FILE\fR
+.SH "DESCRIPTION"
+.sp
+A DocBook toolchain manager that translates an AsciiDoc text file \fISOURCE_FILE\fR to PDF, EPUB, DVI, PS, LaTeX, XHTML (single page or chunked), man page, HTML Help or plain text formats using \fIasciidoc(1)\fR and other applications (see REQUISITES section)\&. \fISOURCE_FILE\fR can also be a DocBook file with an \&.xml extension\&.
+.SH "OPTIONS"
+.PP
+\fB\-a, \-\-attribute\fR=\fIATTRIBUTE\fR
+.RS 4
+Set asciidoc(1) attribute value (shortcut for
+\fB\-\-asciidoc\-opts\fR=\fI"\-a ATTRIBUTE"\fR
+option)\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-asciidoc\-opts\fR=\fIASCIIDOC_OPTS\fR
+.RS 4
+Additional
+\fIasciidoc(1)\fR
+options\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-conf\-file\fR=\fICONF_FILE\fR
+.RS 4
+Load configuration file\&. See
+CONF FILES section\&.
+.RE
+.PP
+\fB\-D, \-\-destination\-dir\fR=\fIDESTINATION_DIR\fR
+.RS 4
+Output directory\&. Defaults to
+\fISOURCE_FILE\fR
+directory\&. This option is only applicable to HTML based output formats (\fIchunked\fR,
+\fIepub\fR,
+\fIhtmlhelp\fR,
+\fIxhtml\fR)\&.
+.RE
+.PP
+\fB\-d, \-\-doctype\fR=\fIDOCTYPE\fR
+.RS 4
+DocBook document type:
+\fIarticle\fR,
+\fImanpage\fR
+or
+\fIbook\fR\&. Default document type is
+\fIarticle\fR
+unless the format is
+\fImanpage\fR
+(in which case it defaults to
+\fImanpage\fR)\&.
+.RE
+.PP
+\fB\-b, \-\-backend\fR=\fIBACKEND\fR
+.RS 4
+\fIBACKEND\fR
+is the name of an installed backend plugin\&. When this option is specified
+\fIa2x\fR
+attempts to load a file name
+\fIa2x\-backend\&.py\fR
+from the
+\fIBACKEND\fR
+plugin directory\&. It then converts the
+\fISOURCE_FILE\fR
+to a
+\fIBACKEND\fR
+formatted output file using a global function defined in
+\fIa2x\-backend\&.py\fR
+called
+\fIto_BACKEND\fR\&.
+.RE
+.PP
+\fB\-f, \-\-format\fR=\fIFORMAT\fR
+.RS 4
+Output formats:
+\fIchunked\fR,
+\fIdocbook\fR,
+\fIdvi\fR,
+\fIepub\fR,
+\fIhtmlhelp\fR,
+\fImanpage\fR,
+\fIpdf\fR
+(default),
+\fIps\fR,
+\fItex\fR,
+\fItext\fR,
+\fIxhtml\fR\&. The AsciiDoc
+\fIa2x\-format\fR
+attribute value is set to
+\fIFORMAT\fR\&.
+.RE
+.PP
+\fB\-h, \-\-help\fR
+.RS 4
+Print command\-line syntax and program options to stdout\&.
+.RE
+.PP
+\fB\-\-icons\fR
+.RS 4
+Use admonition or navigation icon images in output documents\&. The default behavior is to use text in place of icons\&.
+.RE
+.PP
+\fB\-\-icons\-dir\fR=\fIPATH\fR
+.RS 4
+A path (relative to output files) containing admonition and navigation icons\&. Defaults to
+images/icons\&. The
+\fI\-\-icons\fR
+option is implicit if this option is used\&.
+.RE
+.PP
+\fB\-k, \-\-keep\-artifacts\fR
+.RS 4
+Do not delete temporary build files\&.
+.RE
+.PP
+\fB\-\-lynx\fR
+.RS 4
+Use
+\fIlynx(1)\fR
+(actually: the text\-based browser defined by the
+LYNX
+config variable) when generating text formatted output\&. The default behavior is to use
+\fIw3m(1)\fR
+(actually: the text\-based browser defined by the
+W3M
+config variable)\&.
+.RE
+.PP
+\fB\-L, \-\-no\-xmllint\fR
+.RS 4
+Do not check asciidoc output with
+\fIxmllint(1)\fR\&.
+.RE
+.PP
+\fB\-\-\-epubcheck\fR
+.RS 4
+Check EPUB output with
+\fIepubcheck(1)\fR\&.
+.RE
+.PP
+\fB\-n, \-\-dry\-run\fR
+.RS 4
+Do not do anything just print what would have been done\&.
+.RE
+.PP
+\fB\-r, \-\-resource\fR=\fIRESOURCE_SPEC\fR
+.RS 4
+Specify a resource\&. This option may be specified more than once\&. See the
+\fBRESOURCES\fR
+section for more details\&.
+.RE
+.PP
+\fB\-m, \-\-resource\-manifest\fR=\fIFILE\fR
+.RS 4
+\fIFILE\fR
+contains a list resources (one per line)\&. Manifest
+\fIFILE\fR
+entries are formatted just like
+\fB\-\-resource\fR
+option arguments\&. Environment variables and tilde home directories are allowed\&.
+.RE
+.PP
+\fB\-\-stylesheet\fR=\fISTYLESHEET\fR
+.RS 4
+A space delimited list of one or more CSS stylesheet file names that are used to style HTML output generated by DocBook XSL Stylesheets\&. Defaults to
+\fIdocbook\-xsl\&.css\fR\&. The stylesheets are processed in list order\&. The stylesheets must reside in a valid
+resource file
+location\&. Applies to HTML formats:
+\fIxhtml\fR,
+\fIepub\fR,
+\fIchunked\fR,
+\fIhtmlhelp\fR
+formats\&.
+.RE
+.PP
+\fB\-v, \-\-verbose\fR
+.RS 4
+Print operational details to stderr\&. A second
+\fB\-v\fR
+option applies the verbose option to toolchain commands\&.
+.RE
+.PP
+\fB\-\-version\fR
+.RS 4
+Print program version to stdout\&.
+.RE
+.PP
+\fB\-\-xsltproc\-opts\fR=\fIXSLTPROC_OPTS\fR
+.RS 4
+Additional
+\fIxsltproc(1)\fR
+options\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-xsl\-file\fR=\fIXSL_FILE\fR
+.RS 4
+Override the built\-in XSL stylesheet with the custom XSL stylesheet
+\fIXSL_FILE\fR\&.
+.RE
+.PP
+\fB\-\-fop\fR
+.RS 4
+Use FOP to generate PDFs\&. The default behavior is to use
+\fIdblatex(1)\fR\&. The
+\fI\-\-fop\fR
+option is implicit if this option is used\&.
+.RE
+.PP
+\fB\-\-fop\-opts\fR=\fIFOP_OPTS\fR
+.RS 4
+Additional
+\fIfop(1)\fR
+options\&. If this option is specified FOP is used to generate PDFs\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-dblatex\-opts\fR=\fIDBLATEX_OPTS\fR
+.RS 4
+Additional
+\fIdblatex(1)\fR
+options\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-backend\-opts\fR=\fIBACKEND_OPTS\fR
+.RS 4
+Options for the backend plugin specified by the
+\fI\-\-backend\fR
+option\&. This option may be specified more than once\&.
+.RE
+.sp
+Options can also be set in the AsciiDoc source file\&. If \fISOURCE_FILE\fR contains a comment line beginning with \fB// a2x:\fR then the remainder of the line will be treated as \fIa2x\fR command\-line options\&. For example:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// a2x default options\&.
+//    a2x: \-dbook \-\-epubcheck
+// Suppress revision history in dblatex outputs\&.
+//    a2x: \-\-dblatex\-opts "\-P latex\&.output\&.revhistory=0"
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Options spanning multiple such comment lines will be concatenated\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Zero or more white space characters can appear between the leading
+\fB//\fR
+and
+\fBa2x:\fR\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Command\-line options take precedence over options set in the source file\&.
+.RE
+.SH "OUTPUT FILES"
+.sp
+Output files are written to the directory specified by the \fB\-\-destination\-dir\fR option\&. If no \fB\-\-destination\-dir\fR option is set output files are written to the \fISOURCE_FILE\fR directory\&.
+.sp
+Output files have the same name as the \fISOURCE_FILE\fR but with an appropriate file name extension: \&.html for \fIxhtml\fR; \&.epub for \fIepub\fR; \&.hhp for \fIhtmlhelp\fR; \&.pdf for \fIpdf\fR; \&.text for \fItext\fR, \&.xml for \fIdocbook\fR\&. By convention manpages have no \&.man extension (man page section number only)\&. Chunked HTML directory names have a \&.chunked extension; chunked HTML Help directory names have a \&.htmlhelp extension\&.
+.sp
+Same named existing files are overwritten\&.
+.sp
+In addition to generating HTML files the \fIxhtml\fR, \fIepub\fR, \fIchunked\fR and \fIhtmlhelp\fR formats ensure resource files are copied to their correct destination directory locations\&.
+.SH "RESOURCES"
+.sp
+Resources are files (typically CSS and images) that are required by HTML based outputs (\fIxhtml\fR, \fIepub\fR, \fIchunked\fR, \fIhtmlhelp\fR formats)\&. \fIa2x\fR scans the generated HTML files and builds a list of required CSS and image files\&. Additional resource files can be specified explicitly using the \fB\-\-resource\fR option\&.
+.sp
+\fIa2x\fR searches for resource files in the following locations in the following order:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  1." 4.2
+.\}
+The
+\fISOURCE_FILE\fR
+directory\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  2." 4.2
+.\}
+Resource directories specified by the
+\fB\-\-resource\fR
+option (searched recursively)\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 3.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  3." 4.2
+.\}
+Resource directories specified by the
+\fB\-\-resource\-manifest\fR
+option (searched recursively in the order they appear in the manifest file)\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 4.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  4." 4.2
+.\}
+The stock
+images
+and
+stylesheets
+directories in the
+\fIasciidoc(1)\fR
+configuration files directories (searched recursively)\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 5.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  5." 4.2
+.\}
+The destination directory\&.
+.RE
+.sp
+When a resource file is found it is copied to the correct relative destination directory\&. Missing destination sub\-directories are created automatically\&.
+.sp
+There are two distinct mechanisms for specifying additional resources:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  1." 4.2
+.\}
+A resource directory which will be searched recursively for missing resource files\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  2." 4.2
+.\}
+A resource file which will be copied to the output destination directory\&.
+.RE
+.sp
+Resources are specified with \fB\-\-resource\fR option values which can be one of the following formats:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+<resource_dir>
+<resource_file>[=<destination_file>]
+\&.<ext>=<mimetype>
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Where:
+.PP
+<resource_dir>
+.RS 4
+Specifies a directory (absolute or relative to the
+\fISOURCE_FILE\fR) which is searched recursively for missing resource files\&. To eliminate ambiguity the
+<resource_dir>
+name should end with a directory separator character\&.
+.RE
+.PP
+<resource_file>
+.RS 4
+Specifies a resource file (absolute or relative to the
+\fISOURCE_FILE\fR) which will be copied to
+<destination_file>\&. If
+<destination_file>
+is not specified then it is the same as the
+<resource_file>\&.
+.RE
+.PP
+<destination_file>
+.RS 4
+Specifies the destination of the copied source file\&. The
+<destination_file>
+path is relative to the destination directory (absolute paths are not allowed)\&. The location of the destination directory depends on the output
+\fIFORMAT\fR
+(see the
+\fBOUTPUT FILES\fR
+section for details):
+.PP
+chunked, htmlhelp
+.RS 4
+The chunked output directory\&.
+.RE
+.PP
+epub
+.RS 4
+The archived
+OEBPS
+directory\&.
+.RE
+.PP
+xhtml
+.RS 4
+The output
+\fBDESTINATION_DIR\fR\&.
+.RE
+.RE
+.PP
+\&.<ext>=<mimetype>
+.RS 4
+When adding resources to EPUB files the mimetype is inferred from the
+<destination file>
+extension, if the mimetype cannot be guessed an error occurs\&. The
+\&.<ext>=<mimetype>
+resource syntax can be used to explicitly set mimetypes\&.
+<ext>
+is the file name extension,
+<mimetype>
+is the corresponding MIME type\&.
+.RE
+.sp
+Resource option examples:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+\-\-resource \&.\&./images/
+\-\-resource doc/README\&.txt=README\&.txt
+\-\-resource ~/images/tiger\&.png=images/tiger\&.png
+\-\-resource \&.ttf=application/x\-font\-ttf
+.fi
+.if n \{\
+.RE
+.\}
+.SH "EXAMPLES"
+.PP
+a2x \-f pdf doc/source\-highlight\-filter\&.txt
+.RS 4
+Generates
+doc/source\-highlight\-filter\&.pdf
+file\&.
+.RE
+.PP
+a2x \-f xhtml \-D \&.\&./doc \-\-icons \-r \&.\&./images/ team\&.txt
+.RS 4
+Creates HTML file
+\&.\&./doc/team\&.html, uses admonition icons and recursively searches the
+\&.\&./images/
+directory for any missing resources\&.
+.RE
+.PP
+a2x \-f manpage doc/asciidoc\&.1\&.txt
+.RS 4
+Generate
+doc/asciidoc\&.1
+manpage\&.
+.RE
+.SH "REQUISITES"
+.sp
+\fIa2x\fR uses the following programs:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBAsciidoc\fR:
+http://asciidoc\&.org/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBxsltproc\fR: (all formats except text):
+http://xmlsoft\&.org/XSLT/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBDocBook XSL Stylesheets\fR
+(all formats except text):
+http://docbook\&.sourceforge\&.net/projects/xsl/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBdblatex\fR
+(pdf, dvi, ps, tex formats):
+http://dblatex\&.sourceforge\&.net/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBFOP\fR
+(pdf format \(em alternative PDF file generator):
+http://xmlgraphics\&.apache\&.org/fop/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBw3m\fR
+(text format):
+http://w3m\&.sourceforge\&.net/index\&.en\&.html
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBLynx\fR
+(text format \(em alternative text file generator):
+http://lynx\&.isc\&.org/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBepubcheck\fR
+(epub format \(em EPUB file validator):
+http://code\&.google\&.com/p/epubcheck/
+.RE
+.sp
+See also the latest README file\&.
+.SH "CONF FILES"
+.sp
+A configuration file contains executable Python code that overrides the global configuration parameters in a2x\&.py\&. Optional configuration files are loaded in the following order:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  1." 4.2
+.\}
+a2x\&.conf
+from the directory containing the
+\fIa2x\&.py\fR
+executable\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  2." 4.2
+.\}
+a2x\&.conf
+from the AsciiDoc global configuration directory\&. Skip this step if we are executing a locally installed (non system wide) copy\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 3.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  3." 4.2
+.\}
+a2x\&.conf
+from the AsciiDoc
+$HOME/\&.asciidoc
+configuration directory\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 4.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  4." 4.2
+.\}
+The
+\fICONF_FILE\fR
+specified in the
+\fI\-\-conf\-file\fR
+option\&.
+.RE
+.sp
+Here are the default configuration file option values:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# Optional environment variable dictionary passed to
+# executing programs\&. If set to None the existing
+# environment is used\&.
+ENV = None
+
+# External executables\&.
+ASCIIDOC = \*(Aqasciidoc\*(Aq
+XSLTPROC = \*(Aqxsltproc\*(Aq
+DBLATEX = \*(Aqdblatex\*(Aq         # pdf generation\&.
+FOP = \*(Aqfop\*(Aq                 # pdf generation (\-\-fop option)\&.
+W3M = \*(Aqw3m\*(Aq                 # primary text file generator\&.
+LYNX = \*(Aqlynx\*(Aq               # alternate text file generator\&.
+XMLLINT = \*(Aqxmllint\*(Aq         # Set to \*(Aq\*(Aq to disable\&.
+EPUBCHECK = \*(Aqepubcheck\*(Aq     # Set to \*(Aq\*(Aq to disable\&.
+# External executable default options\&.
+ASCIIDOC_OPTS = \*(Aq\*(Aq
+BACKEND_OPTS = \*(Aq\*(Aq
+DBLATEX_OPTS = \*(Aq\*(Aq
+FOP_OPTS = \*(Aq\*(Aq
+LYNX_OPTS = \*(Aq\-dump\*(Aq
+W3M_OPTS = \*(Aq\-dump \-cols 70 \-T text/html \-no\-graph\*(Aq
+XSLTPROC_OPTS = \*(Aq\*(Aq
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Note, that it is possible to redefine W3M and LYNX to use different text\-based browsers, e\&.g\&. \fIlinks\fR: http://links\&.twibright\&.com/ or \fIelinks\fR: http://elinks\&.or\&.cz/\&. LYNX_OPTS and W3M_OPTS can be used to pass options to the selected browser\&. If these are defined they override the respective defaults listed above (so don\(cqt forget to include the \fI\-dump\fR option in your definition: this is mandatory at least with \fIw3m\fR, \fIlynx\fR, \fIlinks\fR, and \fIelinks\fR in order to send the formatted text to stdout)\&.
+.SH "BUGS"
+.sp
+See the AsciiDoc distribution BUGS file\&.
+.SH "AUTHOR"
+.sp
+a2x was originally written by Stuart Rackham\&. Many people have contributed to it\&.
+.SH "RESOURCES"
+.sp
+SourceForge: http://sourceforge\&.net/projects/asciidoc/
+.sp
+Main web site: http://asciidoc\&.org/
+.SH "SEE ALSO"
+.sp
+asciidoc(1)
+.SH "COPYING"
+.sp
+Copyright (C) 2002\-2011 Stuart Rackham\&. Free use of this software is granted under the terms of the MIT license\&.

--- a/doc/asciidoc.1
+++ b/doc/asciidoc.1
@@ -1,0 +1,335 @@
+'\" t
+.\"     Title: asciidoc
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
+.\"      Date: 04/11/2015
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "ASCIIDOC" "1" "04/11/2015" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+asciidoc \- converts an AsciiDoc text file to HTML or DocBook
+.SH "SYNOPSIS"
+.sp
+\fBasciidoc\fR [\fIOPTIONS\fR] \fIFILE\fR
+.SH "DESCRIPTION"
+.sp
+The asciidoc(1) command translates the AsciiDoc text file \fIFILE\fR to DocBook or HTML\&. If \fIFILE\fR is \fI\-\fR then the standard input is used\&.
+.SH "OPTIONS"
+.PP
+\fB\-a, \-\-attribute\fR=\fIATTRIBUTE\fR
+.RS 4
+Define or delete document attribute\&.
+\fIATTRIBUTE\fR
+is formatted like
+\fINAME=VALUE\fR\&. Command\-line attributes take precedence over document and configuration file attributes\&. Alternate acceptable forms are
+\fINAME\fR
+(the
+\fIVALUE\fR
+defaults to an empty string);
+\fINAME!\fR
+(delete the
+\fINAME\fR
+attribute);
+\fINAME=VALUE@\fR
+(do not override document or configuration file attributes)\&. Values containing spaces should be enclosed in double\-quote characters\&. This option may be specified more than once\&. A special attribute named
+\fItrace\fR
+controls the output of diagnostic information\&.
+.RE
+.PP
+\fB\-b, \-\-backend\fR=\fIBACKEND\fR
+.RS 4
+Backend output file format:
+\fIdocbook45\fR,
+\fIxhtml11\fR,
+\fIhtml4\fR,
+\fIhtml5\fR,
+\fIslidy\fR,
+\fIwordpress\fR
+or
+\fIlatex\fR
+(the
+\fIlatex\fR
+backend is experimental)\&. You can also use the backend alias names
+\fIhtml\fR
+(aliased to
+\fIxhtml11\fR) or
+\fIdocbook\fR
+(aliased to
+\fIdocbook45\fR)\&. Defaults to
+\fIhtml\fR\&. The
+\fB\-\-backend\fR
+option is also used to manage backend plugins (see
+\fBPLUGIN COMMANDS\fR)\&.
+.RE
+.PP
+\fB\-f, \-\-conf\-file\fR=\fICONF_FILE\fR
+.RS 4
+Use configuration file
+\fICONF_FILE\fR\&.Configuration files processed in command\-line order (after implicit configuration files)\&. This option may be specified more than once\&.
+.RE
+.PP
+\fB\-\-doctest\fR
+.RS 4
+Run Python doctests in
+\fIasciidoc\fR
+module\&.
+.RE
+.PP
+\fB\-d, \-\-doctype\fR=\fIDOCTYPE\fR
+.RS 4
+Document type:
+\fIarticle\fR,
+\fImanpage\fR
+or
+\fIbook\fR\&. The
+\fIbook\fR
+document type is only supported by the
+\fIdocbook\fR
+backend\&. Default document type is
+\fIarticle\fR\&.
+.RE
+.PP
+\fB\-c, \-\-dump\-conf\fR
+.RS 4
+Dump configuration to stdout\&.
+.RE
+.PP
+\fB\-\-filter\fR=\fIFILTER\fR
+.RS 4
+Specify the name of a filter to be loaded (used to load filters that are not auto\-loaded)\&. This option may be specified more than once\&. The
+\fB\-\-filter\fR
+option is also used to manage filter plugins (see
+\fBPLUGIN COMMANDS\fR)\&.
+.RE
+.PP
+\fB\-h, \-\-help\fR [\fITOPIC\fR]
+.RS 4
+Print help TOPIC\&.
+\fB\-\-help\fR\fItopics\fR
+will print a list of help topics,
+\fB\-\-help\fR\fIsyntax\fR
+summarizes AsciiDoc syntax,
+\fB\-\-help\fR\fImanpage\fR
+prints the AsciiDoc manpage\&.
+.RE
+.PP
+\fB\-e, \-\-no\-conf\fR
+.RS 4
+Exclude implicitly loaded configuration files except for those named like the input file (\fIinfile\&.conf\fR
+and
+\fIinfile\-backend\&.conf\fR)\&.
+.RE
+.PP
+\fB\-s, \-\-no\-header\-footer\fR
+.RS 4
+Suppress document header and footer output\&.
+.RE
+.PP
+\fB\-o, \-\-out\-file\fR=\fIOUT_FILE\fR
+.RS 4
+Write output to file
+\fIOUT_FILE\fR\&. Defaults to the base name of input file with
+\fIbackend\fR
+extension\&. If the input is stdin then the outfile defaults to stdout\&. If
+\fIOUT_FILE\fR
+is
+\fI\-\fR
+then the standard output is used\&.
+.RE
+.PP
+\fB\-n, \-\-section\-numbers\fR
+.RS 4
+Auto\-number HTML article section titles\&. Synonym for
+\fB\-\-attribute numbered\fR\&.
+.RE
+.PP
+\fB\-\-safe\fR
+.RS 4
+Enable safe mode\&. Safe mode is disabled by default\&. AsciiDoc
+\fIsafe mode\fR
+skips potentially dangerous scripted sections in AsciiDoc source files\&.
+.RE
+.PP
+\fB\-\-theme\fR=\fITHEME\fR
+.RS 4
+Specify a theme name\&. Synonym for
+\fB\-\-attribute theme\fR=\fITHEME\fR\&. The
+\fB\-\-theme\fR
+option is also used to manage theme plugins (see
+\fBPLUGIN COMMANDS\fR)\&.
+.RE
+.PP
+\fB\-v, \-\-verbose\fR
+.RS 4
+Verbosely print processing information and configuration file checks to stderr\&.
+.RE
+.PP
+\fB\-\-version\fR
+.RS 4
+Print program version number\&.
+.RE
+.SH "PLUGIN COMMANDS"
+.sp
+The asciidoc(1) \fB\-\-filter\fR, \fB\-\-backend\fR and \fB\-\-theme\fR options are used to install, remove and list AsciiDoc filter, backend and theme plugins\&. Syntax:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+asciidoc OPTION install ZIP_FILE [PLUGINS_DIR]
+asciidoc OPTION remove PLUGIN_NAME [PLUGINS_DIR]
+asciidoc OPTION list
+asciidoc OPTION build ZIP_FILE PLUGIN_SOURCE
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Where:
+.PP
+\fBOPTION\fR
+.RS 4
+asciidoc(1)
+\fB\-\-filter\fR,
+\fB\-\-backend\fR
+or
+\fB\-\-theme\fR
+option specifying the type of plugin\&.
+.RE
+.PP
+\fBPLUGIN_NAME\fR
+.RS 4
+A unique plugin name containing only alphanumeric or underscore characters\&.
+.RE
+.PP
+\fBZIP_FILE\fR
+.RS 4
+A Zip file containing plugin resources, the name must start with the plugin name e\&.g\&.
+my_filter\-1\&.0\&.zip
+packages filter
+my_filter\&.
+.RE
+.PP
+\fBPLUGINS_DIR\fR
+.RS 4
+The directory containing installed plugins\&. Each plugin is contained in its own separate subdirectory which has the same name as the plugin\&.
+\fBPLUGINS_DIR\fR
+defaults to the
+$HOME/\&.asciidoc/filters
+(for filter plugins) or
+$HOME/\&.asciidoc/backends
+(for backend plugins) or
+$HOME/\&.asciidoc/themes
+(for theme plugins)\&.
+.RE
+.PP
+\fBPLUGIN_SOURCE\fR
+.RS 4
+The name of a directory containing the plugin source files or the name of a single source file\&.
+.RE
+.sp
+The plugin commands perform as follows:
+.PP
+\fBinstall\fR
+.RS 4
+Create a subdirectory in
+\fBPLUGINS_DIR\fR
+with the same name as the plugin then extract the
+\fBZIP_FILE\fR
+into it\&.
+.RE
+.PP
+\fBremove\fR
+.RS 4
+Delete the
+\fBPLUGIN_NAME\fR
+plugin subdirectory and all its contents from the
+\fBPLUGINS_DIR\fR\&.
+.RE
+.PP
+\fBlist\fR
+.RS 4
+List the names and locations of all installed filter or theme plugins (including standard plugins installed in the global configuration directory)\&.
+.RE
+.PP
+\fBbuild\fR
+.RS 4
+Create a plugin file named
+\fBZIP_FILE\fR
+containing the files and subdirectories specified by
+\fBPLUGIN_SOURCE\fR\&. File and directory names starting with a period are skipped\&.
+.RE
+.SH "EXAMPLES"
+.PP
+asciidoc asciidoc_file_name\&.txt
+.RS 4
+Simply generate an html file from the asciidoc_file_name\&.txt that is in current directory using asciidoc\&.
+.RE
+.PP
+asciidoc \-b html5 asciidoc_file_name\&.txt
+.RS 4
+Use the
+\-b
+switch to use one of the proposed backend or another one you installed on your computer\&.
+.RE
+.PP
+asciidoc \-a data\-uri \-a icons \-a toc \-a max\-width=55em article\&.txt
+.RS 4
+Use the
+\-a
+switch to set attributes from command\-line\&. AsciiDoc generated its stand\-alone HTML user guide containing embedded CSS, JavaScript and images from the AsciiDoc article template with this command\&.
+.RE
+.PP
+asciidoc \-b html5 \-d manpage asciidoc\&.1\&.txt
+.RS 4
+Generating the asciidoc manpage using the html5 backend\&.
+.RE
+.SH "EXIT STATUS"
+.PP
+\fB0\fR
+.RS 4
+Success
+.RE
+.PP
+\fB1\fR
+.RS 4
+Failure (syntax or usage error; configuration error; document processing failure; unexpected error)\&.
+.RE
+.SH "BUGS"
+.sp
+See the AsciiDoc distribution BUGS file\&.
+.SH "AUTHOR"
+.sp
+AsciiDoc was originally written by Stuart Rackham\&. Many people have contributed to it\&.
+.SH "RESOURCES"
+.sp
+SourceForge: http://sourceforge\&.net/projects/asciidoc/
+.sp
+Main web site: http://asciidoc\&.org/
+.SH "SEE ALSO"
+.sp
+a2x(1)
+.SH "COPYING"
+.sp
+Copyright (C) 2002\-2011 Stuart Rackham\&. Free use of this software is granted under the terms of the GNU General Public License (GPL)\&.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+import platform
+import fileinput
+import sys
+import os
+import shutil
+import subprocess
+import gzip
+import glob
+
+if not sys.version_info[0] == 2 and sys.version_info[1] < 4:
+    print "AsciiDoc requires Python 2.4 or newer"
+    sys.exit(1) # return non-zero value for failure
+
+data_files=[
+		('asciidoc/filters/code', ['filters/code/code-filter.py', 'filters/code/code-filter.conf']),
+		('asciidoc/filters/graphviz', ['filters/graphviz/graphviz2png.py', 'filters/graphviz/graphviz-filter.conf']),
+		('asciidoc/filters/music', ['filters/music/music2png.py', 'filters/music/music-filter.conf']),
+		('asciidoc/filters/latex', ['filters/latex/latex2img.py', 'filters/latex/latex-filter.conf']),
+		('asciidoc/filters/source', ['filters/source/source-highlight-filter.conf']),
+		('asciidoc/themes', ['themes/flask/flask.css']),
+		('asciidoc/volnitsky', ['themes/volnitsky/volnitsky.css']),
+		('asciidoc/volnitsky', ['themes/volnitsky/volnitsky.css']),
+]
+
+scripts=["asciidoc.py", "a2x.py"]
+
+if platform.system() == "Windows":
+	data_files.append(
+		("", ["asciidoc.bat"])
+	)
+else:
+	scriptdir = os.path.join("build","scripts")
+	if not os.path.exists(scriptdir):
+		os.makedirs(scriptdir)
+	newScripts = []
+	for s in scripts:
+		newpath = os.path.join(scriptdir, os.path.splitext(s)[0])
+		outFh = open(newpath, "w")
+		inFh = open(s, "r")
+		for line in inFh:
+			if line.startswith("CONF_DIR = '"):
+				line = "CONF_DIR = '/usr/local/asciidoc'%s" % os.linesep
+			outFh.write(line)
+		newScripts.append(newpath)
+	scripts = newScripts
+
+	mantxt = glob.glob("doc/*.1")
+	if not os.path.exists(os.path.join("build","man")):
+		os.makedirs(os.path.join("build","man"))
+	newman = []
+	for mt in mantxt:
+		newname = "%s.gz" % os.path.basename(mt)
+		newpath = os.path.join("build","man","%s" % newname)
+
+		f_in = open(mt, 'rb')
+		f_out = gzip.open(newpath, 'wb')
+		f_out.writelines(f_in)
+		f_out.close()
+		f_in.close()
+
+		newman.append(newpath)
+	
+	data_files.append(
+		(os.path.join('man', 'man1'), newman)
+	)
+
+conf = glob.glob("*.conf")
+conf.extend(
+	glob.glob("README*") + glob.glob("BUGS*") + glob.glob("INSTALL*") + glob.glob("CHANGELOG*")
+)
+
+data_files.append(
+	("asciidoc", conf)
+)
+	
+docbook = glob.glob(os.path.join("docbook-xsl","*.xsl"))
+data_files.append(
+	("asciidoc/docbook-xsl", docbook)
+)
+
+dblatex = glob.glob(os.path.join("dblatex","*.sty"))
+data_files.append(
+	("asciidoc/dblatex", dblatex)
+)
+
+css = glob.glob(os.path.join("stylesheets","*.css"))
+data_files.append(
+	("asciidoc/stylesheets", css)
+)
+
+js = glob.glob(os.path.join("javascripts","*.js"))
+data_files.append(
+	("asciidoc/javascripts", js)
+)
+
+callouts = glob.glob(os.path.join("images", "icons", "callouts","*"))
+data_files.append(
+	("asciidoc/images/icons/callouts", callouts)
+)
+
+icons = glob.glob(os.path.join("images", "icons", "*.png"))
+icons.append("images/icons/README")
+data_files.append(
+	("asciidoc/images/icons", icons)
+)
+	
+setup(name='AsciiDoc',
+	version='8.6.9',
+	description='Human-readable document format using plain-text mark-up conventions',
+	author='AsciiDoc',
+	author_email='',
+	url='http://asciidoc.org/',
+	license="GNU General Public License version 2 (GPLv2).",
+	py_modules=["asciidocapi"],
+	scripts=scripts,
+	data_files=data_files
+)


### PR DESCRIPTION
New setup.py script using distutils python library.
Should run on Windows and Linux. Didn't test it on mac.

On Linux add man pages and rename scripts from asciidoc.py to asciidoc
On Windows add a .bat script

I've commit man page files because to generate them on Linux system with a2x you will need some extra executable that you can be possibly missing on your system like xsltproc.
This fixes issue #69
