### PR TITLE
make delimiters around LaTeX math optional

### DIFF
--- a/docbook45.conf
+++ b/docbook45.conf
@@ -42,29 +42,29 @@ endif::asciidoc7compatible[]
 <simpara><?asciidoc-pagebreak?></simpara>
 
 [blockdef-pass]
-latexmath-style=template="latexmathblock",subs=()
+latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplatex.py"
 
 [macros]
 # math macros.
-(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[]
-(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[]
+(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
+(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
 
 [latexmath-inlinemacro]
 <inlineequation>
-<alt><![CDATA[{passtext}]]></alt>
+<alt><![CDATA[${passtext}$]]></alt>
 <inlinemediaobject><textobject><phrase></phrase></textobject></inlinemediaobject>
 </inlineequation>
 
 [latexmath-blockmacro]
 <informalequation>
-<alt><![CDATA[{passtext}]]></alt>
+<alt><![CDATA[{backslash}[{passtext}{backslash}]]]></alt>
 <mediaobject><textobject><phrase></phrase></textobject></mediaobject>
 </informalequation>
 
 [latexmathblock]
 <equation{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}><title>{title}</title>
 {title%}<informalequation{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>
-<alt><![CDATA[|]]></alt>
+<alt><![CDATA[\[|\]]]></alt>
 <mediaobject><textobject><phrase></phrase></textobject></mediaobject>
 {title#}</equation>
 {title%}</informalequation>

--- a/filters/unwraplatex.py
+++ b/filters/unwraplatex.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+'''
+NAME
+    unwraplatex - Removes delimiters from LaTeX source text
+
+SYNOPSIS
+    latex2img STDIN
+
+DESCRIPTION
+    This filter reads LaTeX source text from STDIN and removes the
+    surrounding \[ and \] delimiters.
+'''
+
+import re, sys
+
+sys.stdout.write(re.sub("(?s)\A(?:\\\\\[\s*)?(.*?)(?:\\\\\])?\Z", "\\1", sys.stdin.read().rstrip()))
+# NOTE append endline in result to prevent 'no output from filter' warning
+sys.stdout.write("\n")

--- a/html5.conf
+++ b/html5.conf
@@ -33,14 +33,16 @@ endif::asciidoc7compatible[]
 
 [blockdef-pass]
 asciimath-style=template="asciimathblock",subs=()
-latexmath-style=template="latexmathblock",subs=()
+latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplatex.py"
 
 [macros]
 (?u)^(?P<name>audio|video)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
 # math macros.
 # Special characters are escaped in HTML math markup.
-(?su)[\\]?(?P<name>asciimath|latexmath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>asciimath|latexmath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+(?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
+(?u)^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
+(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]
 `{passtext}`
@@ -60,20 +62,20 @@ latexmath-style=template="latexmathblock",subs=()
 </div></div>
 
 [latexmath-inlinemacro]
-{passtext}
+${passtext}$
 
 [latexmath-blockmacro]
 <div class="mathblock{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}>
 <div class="content">
 <div class="title">{title}</div>
-{passtext}
+{backslash}[{passtext}{backslash}]
 </div></div>
 
 [latexmathblock]
 <div class="mathblock{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}>
 <div class="content">
 <div class="title">{title}</div>
-|
+\[|\]
 </div></div>
 
 [image-inlinemacro]

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -33,13 +33,15 @@ endif::asciidoc7compatible[]
 
 [blockdef-pass]
 asciimath-style=template="asciimathblock",subs=()
-latexmath-style=template="latexmathblock",subs=()
+latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplatex.py"
 
 [macros]
 # math macros.
 # Special characters are escaped in HTML math markup.
-(?su)[\\]?(?P<name>asciimath|latexmath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>asciimath|latexmath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+(?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
+(?u)^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
+(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]
 `{passtext}`
@@ -59,20 +61,20 @@ latexmath-style=template="latexmathblock",subs=()
 </div></div>
 
 [latexmath-inlinemacro]
-{passtext}
+${passtext}$
 
 [latexmath-blockmacro]
 <div class="mathblock{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}>
 <div class="content">
 <div class="title">{title}</div>
-{passtext}
+{backslash}[{passtext}{backslash}]
 </div></div>
 
 [latexmathblock]
 <div class="mathblock{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}>
 <div class="content">
 <div class="title">{title}</div>
-|
+\[|\]
 </div></div>
 
 [image-inlinemacro]


### PR DESCRIPTION
Remove the delimiters around LaTeX math equations when capturing the
user's input. Then, add the delimiters around LaTeX math equations in
the generated output.

This change makes the behavior of the latexmath block and macros
consistent with the asciimath block and macros. Authors can now
optionally write LaTeX math equations without delimiters in the same way
that AsciiMath is written.

This change _is_ backwards compatible with existing documents.
