### PR TITLE
Fix xref macro docbook output

### DIFF
--- a/docbook45.conf
+++ b/docbook45.conf
@@ -244,7 +244,7 @@ endif::deprecated-quotes[]
 # xref:id[text]
 [xref-inlinemacro]
 <link linkend="{target}">{0}</link>
-{2%}<xref linkend="{target}"/>
+{0%}<xref linkend="{target}"/>
 # <<id,text>>
 [xref2-inlinemacro]
 <link linkend="{1}">{2}</link>


### PR DESCRIPTION
The `xref` macro is testing the wrong attribute so it generated both `<link>` and `<xref>` entities whereas it should only generate one or the other.  Appears to have been copied from the `<< >>` macro and not changed.

Can some PDF users verify this works without other problems and post here please and I will commit.
