### PR TITLE
Fix navigation issue (slidy) when using a fragment identifier other than "(xx)"

### DIFF
--- a/javascripts/slidy.js
+++ b/javascripts/slidy.js
@@ -1273,9 +1273,9 @@ var w3c_slidy = {
       }
     };
 
-    for (i = 0; i < slides.length; ++i)
+    for (i = 0; i < this.slides.length; ++i)
     {
-      if (slides[i] == target)
+      if (this.slides[i] == target)
         return i;  // success
     }
 


### PR DESCRIPTION
Hi!

With slidy, I noticed an issue in the javascript in the `find_slide_number` function.
Only fragments like `#(3)` would work (jumping to page 3), but not `#_my_heading` (should jump to slide "My Heading").
As far as I understood it's a scope issue with the object `slides`. Referencing `this.slides` instead seems to solve the issue.

(Tested with asciidoc 8.6.9 (brew install on OSX) and Chrome 46.)

Kr.
