### PR TITLE
Fixed: Now adds encoding spec to xhtml, so that it is conformant.

### DIFF
--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -525,6 +525,7 @@ cellspacing="0" cellpadding="4">
 </div>
 
 [header]
+<?xml version="1.0" encoding="{encoding}"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{lang=en}">


### PR DESCRIPTION
Submitted PR in lieu of original author. See this thread for details: https://groups.google.com/d/msg/asciidoc/JjV-EqB9CsE/yDWF0nOIEgAJ

Original patch message:

For non-UTF-8 input encodings, for example an input file with
`:Encoding: iso-8859-1` at the top and non-ASCII characters in
the text, this makes XHTML output files work when opened as a file
with strict browsers, such as Firefox.
Without this change, Firefox rightfully complains about the file
being invalid XHTML and refuses to render its contents, like this:

 XML Parsing Error: not well-formed   Location: file:///C:/my.xhtml Line Number 1427, Column 21:
 Zusammenfassung der Änderungen
 --------------------^

The XHTML Specification ( http://www.w3.org/TR/xhtml1/#strict ) says:

  An XML declaration is [...] required when the character encoding of
  the document is other than the default UTF-8 or UTF-16 and no
  encoding was determined by a higher-level protocol.

When a file is opened locally, there is no "higher-level protocol"
such as HTTP that might specify the encoding.
In these cases, the XML declaration is required for files

that are encoded as neither UTF-8 nor UTF-16.
AsciiDoc-generated XHTML should be valid independently of the
transport protocol. Since AsciiDoc does not know how the XHTML files
are going to be used, effectively the XML declaration is required

for all files that are encoded as neither UTF-8 nor UTF-16.

For simplicity of implementation and for clarity, we always add the XML
encoding declaration, even for UTF-8- or UTF-16-encoded documents, which
do not strictly need it.

The original issue report is here, titled "Please add XML encoding
declaration to xhtml.conf, so strict browsers can locally open xhtml":
https://groups.google.com/forum/#!topic/asciidoc/JjV-EqB9CsE
