### PR TITLE
doc/main.aap: fix the README rules

### DIFF
--- a/doc/main.aap
+++ b/doc/main.aap
@@ -53,10 +53,10 @@ TEST_FILES = $*(ROOT).css-embedded.html
 # Filetype build rules.
 #####################################################################
 
-:rule %.epub : %.txt ../README.asciidoc
+:rule %.epub : %.txt
     :sys $A2X -f epub -d book --epubcheck --icons $source
 
-:rule %.text : %.txt ../README.asciidoc
+:rule %.text : %.txt
     # Convert AsciiDoc to HTML then use lynx(1) to convert HTML to text.
     @if not _no.LYNX:
         :print WARNING: lynx(1) unavailable: skipping $target file generation
@@ -69,7 +69,7 @@ TEST_FILES = $*(ROOT).css-embedded.html
         :sys $ASCIIDOC $opt -b html4 -o - $source | \
             lynx -dump -stdin > $target
 
-:rule %.css.html : %.txt ../README.asciidoc
+:rule %.css.html : %.txt
     opt =
     @if source_list[0] == 'asciidoc.1.txt':
         opt += -d manpage
@@ -82,7 +82,7 @@ TEST_FILES = $*(ROOT).css-embedded.html
     @else:
         :print WARNING: xmllint(1) unavailable: skipping validation
 
-:rule %.css-embedded.html : %.txt ../README.asciidoc
+:rule %.css-embedded.html : %.txt
     opt =
     @if source_list[0] == 'asciidoc.1.txt':
         opt += -d manpage
@@ -95,7 +95,7 @@ TEST_FILES = $*(ROOT).css-embedded.html
     @else:
         :print WARNING: xmllint(1) unavailable: skipping validation
 
-:rule %.xml : %.txt ../README.asciidoc
+:rule %.xml : %.txt
     opt =
     @if source_list[0] in ('asciidoc.1.txt','a2x.1.txt'):
         opt += -d manpage
@@ -109,7 +109,7 @@ TEST_FILES = $*(ROOT).css-embedded.html
     @else:
         :print WARNING: xmllint(1) unavailable: skipping validation
 
-:rule %.sgml : %.txt ../README.asciidoc
+:rule %.sgml : %.txt
     opt =
     @if source_list[0] in ('asciidoc.1.txt','a2x.1.txt'):
         opt += -d manpage
@@ -188,6 +188,14 @@ $HTMLHELP_DIR/index.html: asciidoc.xml
 ../CHANGELOG: ../CHANGELOG.text
     # Make CHANGELOG.text and copy to CHANGELOG.
     :copy ../CHANGELOG.text ../CHANGELOG
+
+../README.text : ../README.asciidoc
+    # Convert AsciiDoc to HTML then use lynx(1) to convert HTML to text.
+    @if not _no.LYNX:
+        :print WARNING: lynx(1) unavailable: skipping $target file generation
+    @else:
+        :sys $ASCIIDOC -f ../text.conf -n -b html4 -o - $source | \
+            lynx -dump -stdin > $target
 
 ../README: ../README.text
     # Make README.text and copy to README.


### PR DESCRIPTION
It seems that commit 64c6d316b8475c8252f3924c9decbc5187b75601 overlooked the %.txt placeholders.  This fixes messages like

```
Aap: Do not know how to build "../README.txt"
```

(Note that I've never used AAP before, so here's hoping I didn't botch anything.)

Signed-off-by: Marc Joliet marcec@gmx.de
