### PR TITLE
Process linebreaks and rules for xhtml

### DIFF
--- a/docbook-xsl/xhtml.xsl
+++ b/docbook-xsl/xhtml.xsl
@@ -11,4 +11,15 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
 <xsl:import href="common.xsl"/>
+
+<!-- Line break -->
+<xsl:template match="processing-instruction('asciidoc-br')">
+  <br/>
+</xsl:template>
+
+<!-- Horizontal ruler -->
+<xsl:template match="processing-instruction('asciidoc-hr')">
+  <hr/>
+</xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
I'm not sure why the rules for br and hr are missing from the xhtml xsl file. Any input on this would be appreciated.
