### PR TITLE
Fix dashes after comment bug

### DIFF
--- a/asciidoc.conf
+++ b/asciidoc.conf
@@ -120,6 +120,8 @@ monospacedwords=
 # -- Spaced and unspaced em dashes (entity reference &mdash;).
 # Space on both sides is translated to thin space characters.
 (^-- )=&#8212;&#8201;
+# Fix two dashes after comment bug
+\n//.*\n-- =\n&#8201;&#8212;&#8201;
 (\n-- )|( -- )|( --\n)=&#8201;&#8212;&#8201;
 (\w)--(\w)=\1&#8212;\2
 \\--(?!-)=--

--- a/tests/data/text-comment-two-dashes-and-text-again.txt
+++ b/tests/data/text-comment-two-dashes-and-text-again.txt
@@ -1,0 +1,6 @@
+// Test of bug when line that starts with two dashes after comment line vanishes
+:lang: en
+
+Line 1
+// comment
+-- Line 2

--- a/tests/testasciidoc.conf
+++ b/tests/testasciidoc.conf
@@ -861,3 +861,15 @@ data/lang-en-test.txt
 {'footer-style':'revdate'}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Text, comment, two dashes and text again
+
+% backends
+['xhtml11','html4','html5']
+
+% name
+text-comment-two-dashes-and-text-again
+
+% source
+data/text-comment-two-dashes-and-text-again.txt
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Fix #104 

The bug was in asciidoc.conf:
(\n-- )|( -- )|( --\n)=&#8201;&#8212;&#8201;

So
```
Line 1
// comment
-- Line 2
```

is transformed to
```
Line 1
// comment -- Line 2
```

(because (\n is removed))
and "-- Line 2" vanishes.

So i replaced this line with 
(\n-- )=\n&#8201;&#8212;&#8201;
( -- )|( --\n)=&#8201;&#8212;&#8201;

I tried to add test, but I can't see where expected results are. As far as I can see, they are generated by ./testasciidoc.py update so I can't really see the point of these tests: if expected is generated by program that will be tested, we always get PASSED... Please help.