### PR TITLE
Respect SOURCE_DATE_EPOCH

### DIFF
--- a/asciidoc.py
+++ b/asciidoc.py
@@ -1270,10 +1270,16 @@ def char_encode(s):
 
 def date_time_str(t):
     """Convert seconds since the Epoch to formatted local date and time strings."""
-    t = time.localtime(t)
+    source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH')
+    if source_date_epoch is not None:
+        t = time.gmtime(min(t, int(source_date_epoch)))
+    else:
+        t = time.localtime(t)
     date_str = time.strftime('%Y-%m-%d',t)
     time_str = time.strftime('%H:%M:%S',t)
-    if time.daylight and t.tm_isdst == 1:
+    if source_date_epoch is not None:
+        time_str += ' UTC'
+    elif time.daylight and t.tm_isdst == 1:
         time_str += ' ' + time.tzname[1]
     else:
         time_str += ' ' + time.tzname[0]

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -1268,25 +1268,21 @@ def char_encode(s):
     else:
         return s
 
-def time_str(t):
-    """Convert seconds since the Epoch to formatted local time string."""
+def date_time_str(t):
+    """Convert seconds since the Epoch to formatted local date and time strings."""
     t = time.localtime(t)
-    s = time.strftime('%H:%M:%S',t)
+    date_str = time.strftime('%Y-%m-%d',t)
+    time_str = time.strftime('%H:%M:%S',t)
     if time.daylight and t.tm_isdst == 1:
-        result = s + ' ' + time.tzname[1]
+        time_str += ' ' + time.tzname[1]
     else:
-        result = s + ' ' + time.tzname[0]
+        time_str += ' ' + time.tzname[0]
     # Attempt to convert the localtime to the output encoding.
     try:
-        result = char_encode(result.decode(locale.getdefaultlocale()[1]))
+        time_str = char_encode(time_str.decode(locale.getdefaultlocale()[1]))
     except Exception:
         pass
-    return result
-
-def date_str(t):
-    """Convert seconds since the Epoch to formatted local date string."""
-    t = time.localtime(t)
-    return time.strftime('%Y-%m-%d',t)
+    return date_str, time_str
 
 
 class Lex:
@@ -1453,8 +1449,7 @@ class Document(object):
         Set implicit attributes and attributes in 'attrs'.
         """
         t = time.time()
-        self.attributes['localtime'] = time_str(t)
-        self.attributes['localdate'] = date_str(t)
+        self.attributes['localdate'], self.attributes['localtime'] = date_time_str(t)
         self.attributes['asciidoc-version'] = VERSION
         self.attributes['asciidoc-file'] = APP_FILE
         self.attributes['asciidoc-dir'] = APP_DIR
@@ -1484,8 +1479,7 @@ class Document(object):
             else:
                 t = None
             if t:
-                self.attributes['doctime'] = time_str(t)
-                self.attributes['docdate'] = date_str(t)
+                self.attributes['docdate'], self.attributes['doctime'] = date_time_str(t)
             if self.infile != '<stdin>':
                 self.attributes['infile'] = self.infile
                 self.attributes['indir'] = os.path.dirname(self.infile)

--- a/doc/asciidoc.1.txt
+++ b/doc/asciidoc.1.txt
@@ -162,6 +162,18 @@ The plugin commands perform as follows:
   names starting with a period are skipped.
 
 
+ENVIRONMENT VARIABLES
+---------------------
+
+*`SOURCE_DATE_EPOCH`*::
+  If the `SOURCE_DATE_EPOCH` environment variable is set to a UNIX
+  timestamp, then the `{docdate}`, `{doctime}`, `{localdate}`, and
+  `{localtime}` attributes are computed in the UTC time zone, with any
+  timestamps newer than `SOURCE_DATE_EPOCH` replaced by
+  `SOURCE_DATE_EPOCH`. (This helps software using AsciiDoc to build
+  reproducibly.)
+
+
 EXAMPLES
 --------
 `asciidoc asciidoc_file_name.txt`::

--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -4620,11 +4620,11 @@ predefined intrinsic attributes:
   {basebackend}         html or docbook
   {blockname}           current block name (note 8).
   {brvbar}              broken vertical bar (|) character
-  {docdate}             document last modified date
+  {docdate}             document last modified date (note 9)
   {docdir}              document input directory name  (note 5)
   {docfile}             document file name  (note 5)
   {docname}             document file name without extension (note 6)
-  {doctime}             document last modified time
+  {doctime}             document last modified time (note 9)
   {doctitle}            document title (from document header)
   {doctype-<doctype>}   empty string ''
   {doctype}             document type specified by `-d` option
@@ -4642,8 +4642,8 @@ predefined intrinsic attributes:
   {ldquo}               Left double quote character (note 7)
   {level}               title level 1..4 (in section titles)
   {listindex}           the list index (1..) of the most recent list item
-  {localdate}           the current date
-  {localtime}           the current time
+  {localdate}           the current date (note 9)
+  {localtime}           the current time (note 9)
   {lsquo}               Left single quote character (note 7)
   {lt}                  less than (<) character entity
   {manname}             manpage name (defined in NAME section)
@@ -4714,6 +4714,13 @@ predefined intrinsic attributes:
    glossary
 
    tables:: table
+9. If the `SOURCE_DATE_EPOCH` environment variable is set to a UNIX
+   timestamp, then the `{docdate}`, `{doctime}`, `{localdate}`, and
+   `{localtime}` attributes are computed in the UTC time zone, with any
+   timestamps newer than `SOURCE_DATE_EPOCH` replaced by
+   `SOURCE_DATE_EPOCH`. (This helps software using AsciiDoc to build
+   reproducibly.)
+
 
 ======
 


### PR DESCRIPTION
If the [SOURCE_DATE_EPOCH environment variable](https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal) is set, then (1) use UTC for all timestamps and (2) replace all timestamps with min(timestamp, SOURCE_DATE_EPOCH). This allows projects using AsciiDoc to build reproducibly without being patched to pass extra flags.

(We don’t expose UTC timestamps as a separate command line option as in #70, but that shouldn’t be necessary because a user who knows they want UTC can run `env TZ=UTC asciidoc`. The goal here is to enable reproducibility without requiring special consideration by all AsciiDoc users.)