### PR TITLE
Prepare 8.6.10 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,15 @@ AsciiDoc ChangeLog
 :website: http://asciidoc.org/
 
 
+Version 8.6.10 (2017-09-22)
+---------------------------
+.Additions and changes
+- Improve reproducibility of builds (e.g. support SOURCE_DATE_EPOCH)
+- Add SVG output support
+- Improve documentation
+- Update translations
+- Full list of changes is at https://github.com/asciidoc/asciidoc/compare/asciidoc:8.6.9...asciidoc:8.6.10
+
 Version 8.6.9 (2013-11-09)
 --------------------------
 .Additions and changes

--- a/a2x.py
+++ b/a2x.py
@@ -24,7 +24,7 @@ import mimetypes
 import codecs
 
 PROG = os.path.basename(os.path.splitext(__file__)[0])
-VERSION = '8.6.9'
+VERSION = '8.6.10'
 
 # AsciiDoc global configuration file directory.
 # NOTE: CONF_DIR is "fixed up" by Makefile -- don't rename or change syntax.

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -9,7 +9,7 @@ under the terms of the GNU General Public License (GPL).
 import sys, os, re, time, traceback, tempfile, subprocess, codecs, locale, unicodedata, copy
 
 ### Used by asciidocapi.py ###
-VERSION = '8.6.9'           # See CHANGLOG file for version history.
+VERSION = '8.6.10'           # See CHANGLOG file for version history.
 
 MIN_PYTHON_VERSION = '2.4'  # Require this version of Python or better.
 

--- a/common.aap
+++ b/common.aap
@@ -2,8 +2,8 @@
 # Executed by all main.aap's before anything else.
 #
 
-_parent.VERS = 8.6.9
-_parent.DATE = 9 November 2013
+_parent.VERS = 8.6.10
+_parent.DATE = 22 September 2017
 
 all:
     :pass

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(asciidoc, 8.6.9)
+AC_INIT(asciidoc, 8.6.10)
 
 AC_CONFIG_FILES(Makefile)
 

--- a/examples/website/build-website.sh
+++ b/examples/website/build-website.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-VERS="8.6.9"
-DATE="2013-11-09"
+VERS="8.6.10"
+DATE="2017-09-22"
 
 # Leave the desired layout uncommented.
 #LAYOUT=layout1      # Tables based layout.


### PR DESCRIPTION
I really would love to see a new release to include it in openSUSE.
Not just for issue #103

The ChangeLog might need some more love from someone more involved.
And after this is merged and tested, a 8.6.10 tag should be added.