### PR TITLE
Quick support for inclusion of vector-rendered graphviz into PDF

### DIFF
--- a/filters/graphviz/graphviz-filter.conf
+++ b/filters/graphviz/graphviz-filter.conf
@@ -38,6 +38,22 @@ ifdef::basebackend-xhtml11[]
 <div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>
 </div>
 endif::basebackend-xhtml11[]
+ifdef::basebackend-docbook[]
+[graphviz-svg-block]
+<figure{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{pgwide-option? pgwide="1"}><title>{title}</title>
+{title%}<informalfigure{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>{pgwide-option?<?dbfo pgwide="1"?>}
+# DocBook XSL Stylesheets custom processing instructions.
+<?dbfo keep-together="{breakable-option#auto}"?>
+<?dbfo keep-together="{unbreakable-option#always}"?>
+<mediaobject>
+  <imageobject>
+  <imagedata format="SVG" fileref="{svgsdir=}{svgsdir?/}{target}"{width? contentwidth="{width}"}{height? contentdepth="{height}"}{scale? scale="{scale}"}{scaledwidth? width="{scaledwidth}" scalefit="1"}{align? align="{align}"}/>
+  </imageobject>
+  <textobject><phrase>{alt={target}}</phrase></textobject>
+</mediaobject>
+{title%}</informalfigure>
+{title#}</figure>
+endif::basebackend-docbook[]
 
 #
 # DEPRECATED: Pre 8.2.7 filter definition.


### PR DESCRIPTION
Following #122.

Solution based on "the (not very tested) example" provided by Lex Trotman on
https://groups.google.com/forum/#!topic/asciidoc/IddY7N7aIl4

Works for me on Ubuntu 16.04: generated good PDF, html, tex. 

Save the text below to test it:

```
== Exemple of vector graphviz in PDF

Assuming this is saved as
`asciidoc_graphviz_svg_docbook_pdf.asciidoc.txt`, render with:

       a2x -f pdf asciidoc_graphviz_svg_docbook_pdf.asciidoc.txt



["graphviz", "helloworld.svg", format="svg"]
---------------------------------------------------------------------
digraph helloworld {
hello->world;
}
---------------------------------------------------------------------

```

Open for discussion.

Regards.