### PR TITLE
Fix build by removing reference to obsolete and no longer needed PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - 2.6
   - 2.7
 install:
-  # 12.04 LTS ships an outdated texlive https://launchpad.net/bugs/712521
-  - sudo add-apt-repository --yes ppa:texlive-backports/ppa
   - sudo apt-get update -yq2
   - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base
 script:


### PR DESCRIPTION
Fix build by removing reference to obsolete and no longer needed PPA (only Ubuntu 12.04 needed it)

As you can see, build is broken since commit b0516e2 (2017-09-04), travis says:
https://travis-ci.org/asciidoc/asciidoc/builds/271493176

> E: Failed to fetch http://ppa.launchpad.net/texlive-backports/ppa/ubuntu/dists/trusty/main/binary-amd64/Packages  404  Not Found

This commit 582bfaa fixes it as confirmed by https://travis-ci.org/fidergo-stephane-gourichon/asciidoc/builds/337546713

Thank you for your attention.
