### PR TITLE
Better fix for handling of literallayout elements

### DIFF
--- a/dblatex/asciidoc-dblatex.sty
+++ b/dblatex/asciidoc-dblatex.sty
@@ -16,7 +16,5 @@
   \end{minipage}\end{Sbox}\doublebox{\TheSbox}%
 }
 
-% For DocBook literallayout elements, see `./dblatex/dblatex-readme.txt`.
-\usepackage{alltt}
 % To preserve simple quotes in the blocs of code
 \usepackage{upquote}

--- a/dblatex/asciidoc-dblatex.xsl
+++ b/dblatex/asciidoc-dblatex.xsl
@@ -15,6 +15,7 @@ See dblatex(1) -p option.
   <xsl:param name="table.in.float">0</xsl:param>
   <xsl:param name="monoseq.hyphenation">0</xsl:param>
   <xsl:param name="latex.output.revhistory">1</xsl:param>
+  <xsl:param name="literal.class">normal</xsl:param>
 
   <!-- This doesn't work, don't know why, see:
   http://dblatex.sourceforge.net/html/manual/apas03.html
@@ -40,17 +41,6 @@ figure,table,equation,example
   </xsl:param>
   -->
   <xsl:param name="doc.toc.show">1</xsl:param>
-
-  <!--
-    Override default literallayout template.
-    See `./dblatex/dblatex-readme.txt`.
-  -->
-  <xsl:template match="address|literallayout[@class!='monospaced']">
-    <xsl:text>\begin{alltt}</xsl:text>
-    <xsl:text>&#10;\normalfont{}&#10;</xsl:text>
-    <xsl:apply-templates/>
-    <xsl:text>&#10;\end{alltt}</xsl:text>
-  </xsl:template>
 
   <xsl:template match="processing-instruction('asciidoc-pagebreak')">
     <!-- force hard pagebreak, varies from 0(low) to 4(high) -->

--- a/dblatex/dblatex-readme.txt
+++ b/dblatex/dblatex-readme.txt
@@ -20,19 +20,6 @@ Limitations
 -----------
 Observed in dblatex 0.2.8.
 
-- dblatex doesn't seem to process the DocBook 'literallayout' element
-  correctly: it is rendered in a monospaced font and no inline
-  elements are processed. By default the normal font should be used
-  and almost all DocBook inline elements should be processed
-  (http://www.docbook.org/tdg/en/html/literallayout.html).  I almost
-  fixed this by overriding the default dblatex literallayout template
-  (in `./dblatex/asciidoc-dblatex.xsl`) and using the LaTeX 'alltt'
-  package, but there are remaining problems:
-
-  * Blank lines are replaced by a single space.
-  * The 'literallayout' element incorrectly wraps text when rendered
-    inside a table.
-
 - Callouts do not work inside DocBook 'literallayout' elements which
   means callouts are not displayed inside AsciiDoc literal blocks.  A
   workaround is to change the AsciiDoc literal block to a listing

--- a/docbook45.conf
+++ b/docbook45.conf
@@ -373,7 +373,7 @@ template::[quote-close]
 
 [verseblock]
 template::[quote-open]
-<literallayout>|</literallayout>
+<literallayout class="normal">|</literallayout>
 template::[quote-close]
 
 [quoteparagraph]
@@ -428,7 +428,7 @@ paragraph=<simpara><emphasis role="strong">|</emphasis></simpara>
 paragraph=<simpara><literal>|</literal></simpara>
 
 [tabletags-verse]
-bodydata=<entry align="{halign}" valign="{valign}"{colspan@1:: namest="col_{colstart}" nameend="col_{colend}"}{morerows@0:: morerows="{morerows}"}><literallayout>|</literallayout></entry>
+bodydata=<entry align="{halign}" valign="{valign}"{colspan@1:: namest="col_{colstart}" nameend="col_{colend}"}{morerows@0:: morerows="{morerows}"}><literallayout class="normal">|</literallayout></entry>
 paragraph=
 
 [tabletags-literal]


### PR DESCRIPTION
Since dblatex 0.3.3, literallayout has worked much better.

There is one remaining problem, namely that without an explicit setting of
the parameter literal.class, all literallayout elements are rendered as
monospaced. I have filed a bug (with patch) about this:
https://sourceforge.net/p/dblatex/bugs/116/

This patch improves the handling of literallayout as follows:

1. Remove the override for the default dblatex template, as it’s no longer
needed.

2. Remove the documentation of the problems which no longer exist.

3. In asciidoc-dblatex.sty, don’t use package alltt any more, as it’s not
needed.

4. In docbook45.conf, set class="normal" for verse blocks (also in tables).
This is the “correct” fix.

5. In asciidoc-dblatex.xsl, set literal.class="normal". This is to work
around the remaining bug mentioned above.